### PR TITLE
Session exp per min

### DIFF
--- a/session.c
+++ b/session.c
@@ -113,7 +113,6 @@ int display_session_handler(window_info *win)
 	y = 21;
 	timediff = 0;
 	oa_exp = 0.0f;
-	
 
 	glColor3f(1.0f, 1.0f, 1.0f);
 	safe_snprintf(buffer, sizeof(buffer), "%-20s%-17s%-17s%-17s",


### PR DESCRIPTION
Adjusted calculation for exp/min so that players that have maxed out OA level will still get displayed a exp/min value different than 0.0.
