### PR TITLE
Alternative dialog systems in game launcher

### DIFF
--- a/3d_objects.c
+++ b/3d_objects.c
@@ -108,7 +108,7 @@ void draw_3d_object_detail(object3d * object_id, Uint32 material_index, Uint32 u
 
 	//debug
 
-	if (object_id->self_lit && (!is_day || dungeon) && use_lightning) 
+	if (object_id->self_lit && (!is_day || dungeon) && use_lightning)
 	{
 		glColor3fv(object_id->color);
 	}
@@ -222,7 +222,7 @@ void draw_3d_object_detail(object3d * object_id, Uint32 material_index, Uint32 u
 	}
 	else
 	{
-		glDisable(GL_TEXTURE_2D);		
+		glDisable(GL_TEXTURE_2D);
 	}
 
 
@@ -375,7 +375,7 @@ void draw_3d_objects(unsigned int object_type)
 			anything_under_the_mouse(objects_list[l]->id, UNDER_MOUSE_3D_OBJ);
 		}
 	}
-	
+
 	if (!dungeon && (clouds_shadows || use_shadow_mapping))
 	{
 		ELglActiveTextureARB(detail_unit);
@@ -387,7 +387,7 @@ void draw_3d_objects(unsigned int object_type)
 	disable_buffer_arrays();
 
 	// restore the settings
-	if (is_selflit && (!is_day || dungeon)) 
+	if (is_selflit && (!is_day || dungeon))
 	{
 		glEnable(GL_LIGHTING);
 		glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
@@ -441,15 +441,15 @@ static e3d_object *load_e3d_cache(const char* file_name)
 	// and fill in the data
 	my_strncp(e3d_id->file_name, file_name, sizeof(e3d_id->file_name));
 
+	e3d_id->cache_ptr = cache_add_item(cache_e3d, e3d_id->file_name,
+		e3d_id, sizeof(*e3d_id));
+
 	e3d_id = load_e3d_detail(e3d_id);
 	if (!e3d_id)
 	{
 		LOG_ERROR("Can't load file \"%s\"!", file_name);
 		return NULL;
 	}
-
-	e3d_id->cache_ptr = cache_add_item(cache_e3d, e3d_id->file_name,
-		e3d_id, sizeof(*e3d_id));
 
 	return e3d_id;
 }
@@ -672,13 +672,13 @@ char * get_3dobject_at_location(float x_pos, float y_pos)
 #endif // NEW_SOUND
 
 void display_objects(void)
-{	
+{
 	CHECK_GL_ERRORS();
 	glEnable(GL_CULL_FACE);
 	glEnable(GL_COLOR_MATERIAL);
 	glEnableClientState(GL_VERTEX_ARRAY);
 	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-			
+
 	if (!dungeon && clouds_shadows)
 	{
 		//bind the detail texture
@@ -769,7 +769,7 @@ void display_alpha_objects(void)
 	glEnable(GL_COLOR_MATERIAL);
 	glEnableClientState(GL_VERTEX_ARRAY);
 	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-			
+
 	if (!dungeon && clouds_shadows)
 	{
 		//bind the detail texture
@@ -807,7 +807,7 @@ void display_alpha_objects(void)
 }
 
 void display_blended_objects(void)
-{	
+{
 	CHECK_GL_ERRORS();
 	glEnable(GL_CULL_FACE);
 	glEnable(GL_BLEND);
@@ -815,7 +815,7 @@ void display_blended_objects(void)
 	glEnable(GL_COLOR_MATERIAL);
 	glEnableClientState(GL_VERTEX_ARRAY);
 	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-			
+
 	if (!dungeon && clouds_shadows)
 	{
 		//bind the detail texture

--- a/cache.c
+++ b/cache.c
@@ -199,8 +199,6 @@ void cache_delete(cache_struct *cache)
 	static int cache_delete_loop_block = 0;
 
 	if (!cache) return;
-	if (cache != cache_system)
-		cache_adj_size(cache_system, -cache->total_size, cache);
 	if (cache->cached_items)
 	{
 		cache_remove_all(cache);
@@ -445,7 +443,6 @@ cache_item_struct *cache_add_item(cache_struct *cache, const char* name,
 	}
 	cache->recent_item = cache->cached_items[i] = new_item;
 	cache->num_items++;
-	cache->total_size += size;
 
 	if (cache != cache_system)
 		cache_adj_size(cache_system, size, cache);
@@ -485,7 +482,6 @@ cache_item_struct *cache_add_item(cache_struct *cache, const char* name,
 	cache->cached_items[i]->access_time=cur_time;
 	cache->cached_items[i]->access_count=1;	//start at 0 or 1? Is this a usage
 	cache->num_items++;
-	cache->total_size+=size;
 	if(cache != cache_system) cache_adj_size(cache_system, size, cache);
 	//return the pointer to the detailed item
 	cache->recent_item = cache->cached_items[i];
@@ -498,17 +494,10 @@ void cache_adj_size(cache_struct *cache, Uint32 size, void *item)
 	cache_item_struct *item_ptr = cache_find_ptr(cache, item);
 	if (item_ptr)
 	{
-		// adjust the current size
-		//if(item_ptr->size != size)
-		//{
-			cache->total_size += size;
-			if (cache != cache_system)
-				cache_adj_size(cache_system, size, cache);
-		//}
+        if (cache != cache_system)
+            cache_adj_size(cache_system, size, cache);
 		item_ptr->size += size;
 		cache_use(item_ptr);
-		//item_ptr->access_time=cur_time;
-		//item_ptr->access_count++;
 	}
 }
 
@@ -520,7 +509,6 @@ static void cache_remove(cache_struct *cache, cache_item_struct *item)
 		cache_adj_size(cache_system, -item->size, cache);
 	if (item->cache_item && cache->free_item)
 		(*cache->free_item)(item->cache_item);
-	cache->total_size -= item->size;
 	cache->num_items--;
 	cache->recent_item = NULL;	//forget where we are just incase
 

--- a/cache.c
+++ b/cache.c
@@ -247,11 +247,6 @@ void cache_set_size_limit(cache_struct *cache, Uint32 size_limit)
 	cache->size_limit=size_limit;
 }
 
-void cache_set_free(cache_struct *cache, void (*free_item)())
-{
-	cache->free_item = free_item;
-}
-
 static Uint32 cache_clean(cache_struct *cache)
 {
 	cache_item_struct *item;

--- a/cache.c
+++ b/cache.c
@@ -26,16 +26,6 @@ static void cache_remove(cache_struct *cache, cache_item_struct *item);
 static void cache_remove_all(cache_struct *cache);
 
 #ifdef FASTER_MAP_LOAD
-// Compare two cache items by name. NULL pointer always go beyond "real" items.
-static int cache_item_cmp(const void* i, const void *j)
-{
-	const cache_item_struct *item = *((const cache_item_struct **)i);
-	const cache_item_struct *jtem = *((const cache_item_struct **)j);
-	if (!item) return jtem ? 1 : 0;
-	if (!jtem) return -1;
-	return strcmp(item->name, jtem->name);
-}
-
 // Compare string \a str with the name of item \a iptr.
 static int cache_item_cmp_str(const void* str, const void *iptr)
 {
@@ -507,19 +497,6 @@ cache_item_struct *cache_add_item(cache_struct *cache, const char* name,
 	cache->recent_item = cache->cached_items[i];
 	return(cache->recent_item);
 #endif
-}
-
-void cache_set_name(cache_struct *cache, const char* name, void *item)
-{
-	cache_item_struct *item_ptr = cache_find_ptr(cache, item);
-	if (item_ptr)
-	{
-		item_ptr->name = name;
-#ifdef FASTER_MAP_LOAD
-		qsort(cache->cached_items, cache->num_items, sizeof(item_ptr),
-			cache_item_cmp);
-#endif
-	}
 }
 
 void cache_adj_size(cache_struct *cache, Uint32 size, void *item)

--- a/cache.c
+++ b/cache.c
@@ -182,7 +182,6 @@ cache_struct *cache_init(const char* name, Uint32 max_items,
 	cache->num_allocated = max_items;
 	cache->LRU_time = cur_time;
 	cache->time_limit = 0;	// 0 == no time based LRU check
-	cache->size_limit = 0;	// 0 == no space based LRU check
 	cache->free_item = free_item;
 	cache->compact_item = NULL;
 	if (cache_system)
@@ -230,11 +229,6 @@ void cache_set_compact(cache_struct *cache, Uint32 (*compact_item)())
 void cache_set_time_limit(cache_struct *cache, Uint32 time_limit)
 {
 	cache->time_limit=time_limit;
-}
-
-void cache_set_size_limit(cache_struct *cache, Uint32 size_limit)
-{
-	cache->size_limit=size_limit;
 }
 
 static Uint32 cache_clean(cache_struct *cache)

--- a/cache.h
+++ b/cache.h
@@ -175,20 +175,6 @@ cache_item_struct *cache_add_item(cache_struct *cache, const char* name,
 
 /*!
  * \ingroup cache
- * \brief   sets the \a name of the given \a item in \a cache.
- *
- *      Sets the \a name of the given \a item in \a cache.
- *
- * \param cache     the cache which contains the \a item to change the \a name
- * \param name      the new name of \a item in \a cache
- * \param item      a pointer to the item which \a name should get changed.
- *
- * \callgraph
- */
-void cache_set_name(cache_struct *cache, const char* name, void *item);
-
-/*!
- * \ingroup cache
  * \brief       adjusts the \a size of the given \a item in \a cache.
  *
  *      Adjusts the \a size of the given \a item in \a cache.

--- a/cache.h
+++ b/cache.h
@@ -39,7 +39,6 @@ typedef struct
 #endif
 	Sint32	num_allocated;	/*!< the allocated space for the list */
 	Uint32	LRU_time;		/*!< last time LRU processing done */
-	Uint32	total_size;		/*!< total size currently allocated */
 	Uint32	time_limit;		/*!< limit on LRU time before forcing a scan */
 	void	(*free_item)();	/*!< routine to call to free an item */
 	Uint32	(*compact_item)();	/*!< routine to call to reduce memory usage without freeing */

--- a/cache.h
+++ b/cache.h
@@ -41,7 +41,6 @@ typedef struct
 	Uint32	LRU_time;		/*!< last time LRU processing done */
 	Uint32	total_size;		/*!< total size currently allocated */
 	Uint32	time_limit;		/*!< limit on LRU time before forcing a scan */
-	Uint32	size_limit;		/*!< limit on size before forcing a scan */
 	void	(*free_item)();	/*!< routine to call to free an item */
 	Uint32	(*compact_item)();	/*!< routine to call to reduce memory usage without freeing */
 } cache_struct;
@@ -145,17 +144,6 @@ void cache_set_compact(cache_struct *cache, Uint32 (*compact_item)());
  * \param time_limit    the max. amount of time to live for items in \a cache.
  */
 void cache_set_time_limit(cache_struct *cache, Uint32 time_limit);
-
-/*!
- * \ingroup cache
- * \brief   sets a \a size_limit for items in \a cache.
- *
- *      Sets a \a size_limit in bytes for items in the given \a cache.
- *
- * \param cache         the cache for which the size limit should be set.
- * \param size_limit    the max. size for items in \a cache (in bytes).
- */
-void cache_set_size_limit(cache_struct *cache, Uint32 size_limit);
 
 /*!
  * \ingroup cache

--- a/cache.h
+++ b/cache.h
@@ -159,17 +159,6 @@ void cache_set_size_limit(cache_struct *cache, Uint32 size_limit);
 
 /*!
  * \ingroup cache
- * \brief   sets the function to free items
- *
- *      Sets the function to apply to each item before it is evicted from the
- *      cache.
- *
- * \param free_item     pointer to the free function
- */
-void cache_set_free(cache_struct *cache, void (*free_item)());
-
-/*!
- * \ingroup cache
  * \brief adds the given \a item to \a cache with the given \a name.
  *
  *      Adds the given \a item to \a cache with the given \a name. The parameter \a size determines the maximum size of items in \a cache.

--- a/hash.h
+++ b/hash.h
@@ -1,7 +1,7 @@
 #ifndef __HASH__
 #define __HASH__
 
-#include <SDL.h>
+#include <SDL_types.h>
 
 typedef struct _hash_entry{
 	void *key;
@@ -16,15 +16,15 @@ typedef struct _hash_table{
 
 	hash_entry *cur;
 	int where;
-	
+
 	unsigned long int (*hash_fun)(void *);
 	int (*key_cmp)(void *, void *);
 	void (*free_fun)(void *);
 } hash_table;
 
 
-hash_table *create_hash_table(int size, 
-			     unsigned long int (*hashfn)(void *), 
+hash_table *create_hash_table(int size,
+			     unsigned long int (*hashfn)(void *),
 			     int (*keyfn)(void *, void*),
 			     void (*freefn)(void *)
 );

--- a/init.c
+++ b/init.c
@@ -712,7 +712,6 @@ void init_e3d_cache()
 	cache_e3d = cache_init("E3d cache", 1500, NULL);	//no aut- free permitted
 	cache_set_compact(cache_e3d, &free_e3d_va);	// to compact, free VA arrays
 	cache_set_time_limit(cache_e3d, 5*60*1000);
-	cache_set_size_limit(cache_e3d, 8*1024*1024);
 }
 
 #ifndef FASTER_MAP_LOAD

--- a/pkgfiles/eternallands
+++ b/pkgfiles/eternallands
@@ -18,35 +18,139 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 
+# Show an error message, and exit the script
+show_error()
+{
+	echo -e $1
+	case $dialog in
+	zenity)
+		zenity --error --text="$1"
+		;;
+	dialog)
+		dialog --msgbox "$1" 0 0
+		;;
+	esac
+	exit 1
+}
+
+# Show an information message
+show_info()
+{
+	case $dialog in
+	zenity)
+		zenity --info --text="$1"
+		;;
+	dialog)
+		dialog --msgbox "$1" 0 0
+		;;
+	*)
+		echo -e $1
+		;;
+	esac
+}
+
+# Show a (large) text box with the contents of a file
+show_text_info()
+{
+	case $dialog in
+	zenity)
+		zenity --text-info --width=500 --height=300 --title "$1" --filename="$2"
+		;;
+	dialog)
+		# Ugh, we have the error string in a temporary file, but dialog's textbox
+		# doesn't fold the lines automatically. So try to do it ourselves by
+		# wrapping to the terminal width, minus a bit for the textbox borders,
+		# and write to a second temp file.
+		fold_fname=$(mktemp)
+		columns=$(expr $(tput cols || echo 80) - 5)
+		cat "$2" | fold -w "$columns" -s > "$fold_fname"
+		dialog --title "$1" --textbox "$fold_fname" 80 0
+		rm -f $fold_fname
+		;;
+	*)
+		cat "$2"
+		;;
+	esac
+}
+
+# Show a confirmation dialog. Returns 0 if the user answers "yes" to the
+# question posed, 1 otherwise.
+yes_no()
+{
+	case dialog in
+	zenity)
+		zenity --question --text="$1"
+		;;
+	dialog)
+		dialog --yesno "$1" 0 0
+		;;
+	*)
+		while true
+		do
+			read -p "$1 [y/n]" ans
+			case $ans in
+			[Yy]*)
+				return 0
+				;;
+			[Nn]*)
+				return 1
+				;;
+			*)
+				echo "Please answer yes or no."
+				;;
+			esac
+		done
+	esac
+}
+
 # get users choice from the $serverfile
 getconfig()
 {
-	sort -u $serverfile | tr -d '\015' | grep -v -e ^$ -e ^# | \
-	while read name dir server port description
-	do
-		echo $name
-		echo $description
-		echo $server
-		echo $port
-		echo $dir
-	done | \
-	zenity --title="Eternal Lands Launcher${non_standard}" --width=450 --height=280 \
-		--list \
-		--column "Name" \
-		--column "Description" \
-		--column "Server" \
-		--column "Port" \
-		--column "Directory" \
-		--text "Choose the Server/Configuration - main is the standard"
+	title="Choose the Server/Configuration - main is the standard"
+	case $dialog in
+	zenity)
+		sort -u $serverfile | tr -d '\015' | grep -v -e ^$ -e ^# | \
+		while read name dir server port description
+		do
+			echo $name
+			echo $description
+			echo $server
+			echo $port
+			echo $dir
+		done | \
+		zenity --title="Eternal Lands Launcher${non_standard}" --width=450 --height=280 \
+			--list \
+			--column "Name" \
+			--column "Description" \
+			--column "Server" \
+			--column "Port" \
+			--column "Directory" \
+			--text "${title}"
+		;;
+	dialog)
+		sort -u $serverfile | tr -d '\015' | grep -v -e ^$ -e ^# | \
+		while read name dir server port description
+		do
+			printf "${name}\0${dir}|${server}|${port}|${description}\0"
+		done | \
+		xargs -0 dialog --stdout --column-separator '|' \
+			--menu "${title}" 0 0 10
+		;;
+	*)
+		show_error "No method found to show the server selection screen\n"
+		;;
+	esac
 }
+
+# check which dialog method to use
+for dialog in zenity dialog none; do
+	command -v $dialog > /dev/null 2>&1 && break
+done
 
 # don't run as root
 if [ "$(id -u)" = "0" ]
 then
-	text="Don't run as the root/adminstration user.\n\nJust don't!"
-	echo -e $text
-	zenity --error --text="$text"
-	exit 1
+	show_error "Don't run as the root/administration user.\n\nJust don't!"
 fi
 
 # check the minimum packages are installed OK
@@ -57,8 +161,7 @@ then
 	[ -z "$(dpkg --list eternallands-data | grep ^ii)" ] && installedOK=false
 	if ! $installedOK
 	then
-		zenity --error --text "Eternal Lands is not completely installed. As root or using sudo, please run \"dpkg --configure -a\" to complete the install."
-		exit 1
+		show_error "Eternal Lands is not completely installed. As root or using sudo, please run \"dpkg --configure -a\" to complete the install."
 	fi
 fi
 
@@ -82,7 +185,7 @@ then
 	then
 		non_standard=" (non-standard)"
 		el_client="$tmp_el_client"
-	fi	
+	fi
 fi
 
 # if no command line options specified, see if we want to use the config selection window
@@ -110,13 +213,13 @@ then
 	# if not already configured, choose if to use the server/configuration selection window
 	if [ ! -r $showsel ]
 	then
-		if zenity --question --text="Do you want to choose each time you run the game?"
+		if yes_no "Do you want to choose each time you run the game?"
 		then
 			echo "yes" > $showsel
 		else
 			echo "$config" > $showsel
 		fi
-		zenity --info --text="To change this option, edit or remove the file:\n $showsel"
+		show_info "To change this option, edit or remove the file:\n $showsel"
 	fi
 else
 	config="$1"
@@ -141,7 +244,7 @@ then
 	show_suppression=false
 	if [ "$(grep -a ^#data_dir $inifile | tail -1 | grep -a '^#data_dir = /usr/share/games/EternalLands$')" = "" ]
 	then
-		if zenity --question --text="Warning: $inifile does not use installed game data, shall I fix this problem?"
+		if yes_no "Warning: $inifile does not use installed game data, shall I fix this problem?"
 		then
 			sed -i 's/^#data_dir.*$/#data_dir = \/usr\/share\/games\/EternalLands/g' $inifile
 		else
@@ -150,14 +253,15 @@ then
 	fi
 	if $show_suppression
 	then
-		zenity --info --text="To surpress these warnings, create the file:\n $HOME/.elc/no.el.ini.check"
+		show_info "To surpress these warnings, create the file:\n $HOME/.elc/no.el.ini.check"
 	fi
 fi
 
 # run the client, display error log if it crashes
 if ! $el_client $config $* &> ~/.elc/terminal_log.txt
 then
-	cat | zenity --text-info --width=500 --height=300 --title "Eternal Lands Crashed, this is the Error log." << EOT
+	fout=$(mktemp)
+	cat > $fout << EOT
 Oh my, Eternal Lands Crashed - Don't Panic!
 
 A few of things you can try:
@@ -186,6 +290,8 @@ A search through dmesg output:
 $(dmesg | grep $(basename $el_client))
 
 EOT
+	show_text_info "Eternal Lands Crashed, this is the Error log." $fout
+	rm -f $fout
 	exit 1
 fi
 exit 0

--- a/pkgfiles/eternallands
+++ b/pkgfiles/eternallands
@@ -91,7 +91,6 @@ yes_no()
 		zenity --question --text="$1"
 		;;
     kdialog)
-        echo "yesno"
         kdialog --yesno "$1"
         ;;
 	dialog)

--- a/pkgfiles/eternallands
+++ b/pkgfiles/eternallands
@@ -26,6 +26,9 @@ show_error()
 	zenity)
 		zenity --error --text="$1"
 		;;
+    kdialog)
+        kdialog --error "$1"
+        ;;
 	dialog)
 		dialog --msgbox "$1" 0 0
 		;;
@@ -40,6 +43,9 @@ show_info()
 	zenity)
 		zenity --info --text="$1"
 		;;
+    kdialog)
+        kdialog --msgbox "$1"
+        ;;
 	dialog)
 		dialog --msgbox "$1" 0 0
 		;;
@@ -56,6 +62,9 @@ show_text_info()
 	zenity)
 		zenity --text-info --width=500 --height=300 --title "$1" --filename="$2"
 		;;
+    kdialog)
+        kdialog --title "$1" --textbox "$2" 500 300
+        ;;
 	dialog)
 		# Ugh, we have the error string in a temporary file, but dialog's textbox
 		# doesn't fold the lines automatically. So try to do it ourselves by
@@ -64,7 +73,7 @@ show_text_info()
 		fold_fname=$(mktemp)
 		columns=$(expr $(tput cols || echo 80) - 5)
 		cat "$2" | fold -w "$columns" -s > "$fold_fname"
-		dialog --title "$1" --textbox "$fold_fname" 80 0
+		dialog --title "$1" --textbox "$fold_fname" 0 0
 		rm -f $fold_fname
 		;;
 	*)
@@ -81,13 +90,17 @@ yes_no()
 	zenity)
 		zenity --question --text="$1"
 		;;
+    kdialog)
+        echo "yesno"
+        kdialog --yesno "$1"
+        ;;
 	dialog)
 		dialog --yesno "$1" 0 0
 		;;
 	*)
 		while true
 		do
-			read -p "$1 [y/n]" ans
+			read -p "$1 [y/n] " ans
 			case $ans in
 			[Yy]*)
 				return 0
@@ -127,6 +140,14 @@ getconfig()
 			--column "Directory" \
 			--text "${title}"
 		;;
+    kdialog)
+		sort -u $serverfile | tr -d '\015' | grep -v -e ^$ -e ^# | \
+		while read name dir server port description
+		do
+			printf "${name}\0${dir}\t${server}\t${port}\t${description}\0"
+		done | \
+		xargs -0 kdialog --menu "${title}"
+		;;
 	dialog)
 		sort -u $serverfile | tr -d '\015' | grep -v -e ^$ -e ^# | \
 		while read name dir server port description
@@ -143,7 +164,7 @@ getconfig()
 }
 
 # check which dialog method to use
-for dialog in zenity dialog none; do
+for dialog in zenity kdialog dialog none; do
 	command -v $dialog > /dev/null 2>&1 && break
 done
 

--- a/pkgfiles/eternallands
+++ b/pkgfiles/eternallands
@@ -77,7 +77,7 @@ show_text_info()
 # question posed, 1 otherwise.
 yes_no()
 {
-	case dialog in
+	case $dialog in
 	zenity)
 		zenity --question --text="$1"
 		;;


### PR DESCRIPTION
After reinstalling eternal lands on a new (linux) computer, I found that the game launcher on linux uses zenity for its dialogs. It is a nice system, and the dialogues created are pretty, but I don't have it installed on this box and I don't really want to either. I can imagine more people have been bitten by this. So while it's certainly possible to work around (either install zenity, or start the game directly), let's try to be a bit more user friendly and support more dialog systems.

This patch series introduces support for (terminal) dialog and kdialog in the game launcher. The script uses the first dialog command it can find, checking in order zenity, kdialog, and dialog(*),

Support is not perfect: while both systems (**) somewhat support aligning multiple columns in the menu items of the server selection screen, I can find no way to add column headers as is done in the zenity launcher. Also, the default size of the server selection screen in kdialog is too small, with no apparent way to change it from the command line. Still it is useful to me at least, and it seems to work.

(*) straight console could also be done, in fact all that's needed is to hack up a text-based server selection screen.
(**) kdialog seems to be heavily inspired by dialog, terminology and capabilities are very similar as far as I can see.