### PR TITLE
Add tooltips in map editor toolbox buttons

### DIFF
--- a/elconfig.c
+++ b/elconfig.c
@@ -2992,6 +2992,7 @@ void init_vars(void)
 	add_var(OPT_BOOL,"show_position_on_minimap","spos",&show_position_on_minimap, change_var, 0,"Show Pos","Show position on the minimap",HUD);
 	add_var(OPT_SPECINT,"auto_save","asv",&auto_save_time, set_auto_save_interval, 0,"Auto Save","Auto Save",HUD,0,INT_MAX);
 	add_var(OPT_BOOL,"show_grid","sgrid",&view_grid, change_var, 0, "Show Grid", "Show grid",HUD);
+	add_var(OPT_BOOL,"show_tooltips","stooltips",&view_tooltips, change_var, 0, "Show Tooltips", "Show tooltips",HUD);
 	add_var(OPT_BOOL,"show_reflections","srefl",&show_mapeditor_reflections, change_var, 0, "Show reflections", "Show reflections, disabling improves editor performance",HUD);
 #endif
 #ifndef MAP_EDITOR

--- a/map_editor/editor.h
+++ b/map_editor/editor.h
@@ -6,6 +6,7 @@ extern char heights_3d;
 extern char minimap_on;
 extern int new_map_menu;
 extern int view_grid;
+extern int view_tooltips;
 extern int show_mapeditor_reflections;
 
 #endif

--- a/map_editor/events.c
+++ b/map_editor/events.c
@@ -517,20 +517,58 @@ int HandleEvent(SDL_Event *event)
 
 #endif
     if(event->type==SDL_MOUSEMOTION)
-				{
-					mouse_x= event->motion.x;
-					mouse_y= event->motion.y;
+	{
+		mouse_x= event->motion.x;
+		mouse_y= event->motion.y;
 
-					mouse_delta_x= event->motion.xrel;
-					mouse_delta_y= event->motion.yrel;
-				}
-			else
-				{
-					// why was this here? whats broken by removing it?
-					//mouse_x= event->button.x;
-					//mouse_y= event->button.y;
-					mouse_delta_x= mouse_delta_y= 0;
-				}
+		mouse_delta_x= event->motion.xrel;
+		mouse_delta_y= event->motion.yrel;
+
+		if(mouse_x<15*32 && mouse_y<32) {
+			show_toolbar_tooltip = 1;
+			if(mouse_x>=0 && mouse_x<=31)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Tile");
+			if(mouse_x>=32 && mouse_x<=63)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode 2D");
+			if(mouse_x>=64 && mouse_x<=95)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode 3D");
+			if(mouse_x>=96 && mouse_x<=127)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Particles");
+#ifdef	EYE_CANDY
+			if(mouse_x>=128 && mouse_x<=160)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Eye Candy");
+#endif	//EYE_CANDY
+			if(mouse_x>=160 && mouse_x<=191)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Light");
+			if(mouse_x>=192 && mouse_x<=223)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Height");
+			if(mouse_x>=224 && mouse_x<=255)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Map");
+			if(mouse_x>=256 && mouse_x<=287)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Select");
+			if(mouse_x>=288 && mouse_x<=319)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Clone");
+			if(mouse_x>=320 && mouse_x<=351)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "New Object");
+			if(mouse_x>=352 && mouse_x<=383)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Kill");
+			if(mouse_x>=384 && mouse_x<=415)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Save Map");
+			if(mouse_x>=416 && mouse_x<=447)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Open Map");
+			if (mouse_x >= 448 && mouse_x <= 479)
+				snprintf((char *) tooltip_text, sizeof(tooltip_text), "New Map");
+		} else {
+			show_toolbar_tooltip = 0;
+		}
+	}
+	else
+	{
+		// why was this here? whats broken by removing it?
+		//mouse_x= event->button.x;
+		//mouse_y= event->button.y;
+		mouse_delta_x= mouse_delta_y= 0;
+	}
 
 
 	if(event->type==SDL_MOUSEMOTION || event->type==SDL_MOUSEBUTTONDOWN || event->type==SDL_MOUSEBUTTONUP)

--- a/map_editor/events.c
+++ b/map_editor/events.c
@@ -125,6 +125,7 @@ int HandleEvent(SDL_Event *event)
                     case SDLK_F12:      zoom_level=3.75f; window_resize(); break;
                     case SDLK_TAB:      heights_3d=!heights_3d; break;
                     case SDLK_g:        view_grid=!view_grid; break;
+                    case SDLK_t:        view_tooltips=!view_tooltips; break;
 
                     // FIXME what this?
                     case SDLK_ESCAPE:   done = 1; break;
@@ -524,42 +525,16 @@ int HandleEvent(SDL_Event *event)
 		mouse_delta_x= event->motion.xrel;
 		mouse_delta_y= event->motion.yrel;
 
-		if(mouse_x<15*32 && mouse_y<32) {
-			show_toolbar_tooltip = 1;
-			if(mouse_x>=0 && mouse_x<=31)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Tile");
-			if(mouse_x>=32 && mouse_x<=63)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode 2D");
-			if(mouse_x>=64 && mouse_x<=95)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode 3D");
-			if(mouse_x>=96 && mouse_x<=127)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Particles");
-#ifdef	EYE_CANDY
-			if(mouse_x>=128 && mouse_x<=160)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Eye Candy");
-#endif	//EYE_CANDY
-			if(mouse_x>=160 && mouse_x<=191)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Light");
-			if(mouse_x>=192 && mouse_x<=223)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Height");
-			if(mouse_x>=224 && mouse_x<=255)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Mode Map");
-			if(mouse_x>=256 && mouse_x<=287)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Select");
-			if(mouse_x>=288 && mouse_x<=319)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Clone");
-			if(mouse_x>=320 && mouse_x<=351)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "New Object");
-			if(mouse_x>=352 && mouse_x<=383)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Kill");
-			if(mouse_x>=384 && mouse_x<=415)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Save Map");
-			if(mouse_x>=416 && mouse_x<=447)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "Open Map");
-			if (mouse_x >= 448 && mouse_x <= 479)
-				snprintf((char *) tooltip_text, sizeof(tooltip_text), "New Map");
+		if(mouse_x<TOOLBAR_MAX_BUTTON*TOOLBAR_BUTTON_WIDTH && mouse_y<TOOLBAR_BUTTON_HEIGHT) {
+			toolbar_mouseover = 1;
+			for (int i=0; i<TOOLBAR_MAX_BUTTON; i++) {
+				if (toolbar[i].x_start >= 0 && mouse_x < toolbar[i].x_end) {
+					snprintf((char *) toolbar_tooltip_text, sizeof(toolbar_tooltip_text), toolbar[i].tooltip);
+					break;
+				}
+			}
 		} else {
-			show_toolbar_tooltip = 0;
+			toolbar_mouseover = 0;
 		}
 	}
 	else

--- a/map_editor/global.c
+++ b/map_editor/global.c
@@ -98,8 +98,26 @@ int right_click;
 int left_click;
 int middle_click;
 
-int show_toolbar_tooltip = 1;
-char tooltip_text[MAX_TOOLTIP_SIZE];
+int toolbar_mouseover = 0;
+char toolbar_tooltip_text[MAX_TOOLTIP_SIZE];
+
+toolbar_button toolbar[TOOLBAR_MAX_BUTTON] = {
+		{ (float)64/255,  0.0f,          (float)96/255,  (float)32/255, 0,   0, 32,  32, "Mode Tile"      },
+		{ (float)32/255,  0.0f,          (float)64/255,  (float)32/255, 32,  0, 64,  32, "Mode 2D"        },
+		{ 0.0f,           0.0f,          (float)32/255,  (float)32/255, 64,  0, 96,  32, "Mode 3D"        },
+		{ (float)192/255, (float)32/255, (float)224/255, (float)64/255, 96,  0, 128, 32, "Mode Particles" },
+		{ (float)224/255, (float)32/255, (float)255/255, (float)64/255, 128, 0, 160, 32, "Mode Eye Candy" },
+		{ (float)96/255,  0.0f,          (float)128/255, (float)32/255, 160, 0, 192, 32, "Mode Light"     },
+		{ (float)160/255, (float)32/255, (float)192/255, (float)64/255, 192, 0, 224, 32, "Mode Height"    },
+		{ (float)128/255, 0.0f,          (float)160/255, (float)32/255, 224, 0, 256, 32, "Mode Map"       },
+		{ 0.0f,           (float)32/255, (float)32/255,  (float)64/255, 256, 0, 288, 32, "Select"         },
+		{ (float)32/255,  (float)32/255, (float)64/255,  (float)64/255, 288, 0, 320, 32, "Clone"          },
+		{ (float)224/255, 0.0f,          (float)256/255, (float)32/255, 320, 0, 352, 32, "New Object"     },
+		{ (float)192/255, 0.0f,          (float)224/255, (float)32/255, 352, 0, 384, 32, "Kill"           },
+		{ (float)64/255,  (float)32/255, (float)96/255,  (float)64/255, 384, 0, 416, 32, "Save Map"       },
+		{ (float)96/255,  (float)32/255, (float)128/255, (float)64/255, 416, 0, 448, 32, "Open Map"       },
+		{ (float)128/255, (float)32/255, (float)160/255, (float)64/255, 448, 0, 480, 32, "New Map"        }
+};
 
 int icons_text;
 
@@ -130,6 +148,7 @@ float x_tile_menu_offset=64;
 float y_tile_menu_offset=128;
 char view_new_map_menu=0;
 int view_grid=0;
+int view_tooltips=1;
 
 #if defined(SDL2)
 Uint16 mod_key_status;

--- a/map_editor/global.c
+++ b/map_editor/global.c
@@ -98,6 +98,9 @@ int right_click;
 int left_click;
 int middle_click;
 
+int show_toolbar_tooltip = 1;
+char tooltip_text[MAX_TOOLTIP_SIZE];
+
 int icons_text;
 
 float scene_mouse_x;

--- a/map_editor/interface.c
+++ b/map_editor/interface.c
@@ -186,24 +186,30 @@ void Leave2DMode()
 	glPopAttrib();
 }
 
-
+void draw_toolbar_button(toolbar_button button)
+{
+	draw_2d_thing(
+		button.u_start, button.v_start,
+		button.u_end,   button.v_end,
+		button.x_start, button.y_start,
+		button.x_end,   button.y_end
+	);
+}
 
 void draw_2d_thing(float u_start,float v_start,float u_end,float v_end,int x_start,int y_start,int x_end,int y_end)
-		{
+{
+	glTexCoord2f(u_start,v_end);
+	glVertex3i(x_start,y_end,0);
 
-			glTexCoord2f(u_start,v_end);
-			glVertex3i(x_start,y_end,0);
+	glTexCoord2f(u_start,v_start);
+	glVertex3i(x_start,y_start,0);
 
-			glTexCoord2f(u_start,v_start);
-			glVertex3i(x_start,y_start,0);
+	glTexCoord2f(u_end,v_start);
+	glVertex3i(x_end,y_start,0);
 
-			glTexCoord2f(u_end,v_start);
-			glVertex3i(x_end,y_start,0);
-
-			glTexCoord2f(u_end,v_end);
-			glVertex3i(x_end,y_end,0);
-
-		}
+	glTexCoord2f(u_end,v_end);
+	glVertex3i(x_end,y_end,0);
+}
 
 void draw_toolbar()
 {
@@ -216,89 +222,82 @@ void draw_toolbar()
 	glColor3f(1.0f,1.0f,1.0f);
 	else if(!view_tile && cur_mode!=mode_tile)glColor3f(0.3f,0.3f,0.3f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing((float)64/255, 0.0f, (float)96/255, (float)32/255, 0,0,32,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_MODE_TILE]);
 
 	if(cur_mode!=mode_2d && view_2d)
 	glColor3f(1.0f,1.0f,1.0f);
 	else if(!view_2d && cur_mode!=mode_2d)glColor3f(0.3f,0.3f,0.3f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing((float)32/255, 0.0f,(float)64/255, (float)32/255, 32,0,64,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_MODE_2D]);
 
 	if(cur_mode!=mode_3d && view_3d)
 	glColor3f(1.0f,1.0f,1.0f);
 	else if(!view_3d && cur_mode!=mode_3d)glColor3f(0.3f,0.3f,0.3f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing(0, 0.0f, (float)32/255, (float)32/255, 64,0,96,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_MODE_3D]);
 
 	if(cur_mode!=mode_particles && view_particles)
 	glColor3f(1.0f,1.0f,1.0f);
 	else if(!view_particles && cur_mode!=mode_particles)glColor3f(0.3f,0.3f,0.3f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing((float)192/255, (float)32/255, (float)224/255, (float)64/255, 96,0,128,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_MODE_PARTICLES]);
 
 #ifdef	EYE_CANDY
 	if(cur_mode!=mode_eye_candy && view_eye_candy)
 	glColor3f(1.0f,1.0f,1.0f);
 	else if(!view_eye_candy && cur_mode!=mode_eye_candy)glColor3f(0.3f,0.3f,0.3f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing((float)224/255, (float)32/255, (float)255/255, (float)64/255, 128,0,160,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_MODE_EYE_CANDY]);
 #endif	//EYE_CANDY
 
 	if(cur_mode!=mode_light && view_light)
 	glColor3f(1.0f,1.0f,1.0f);
 	else if(!view_light && cur_mode!=mode_light)glColor3f(0.3f,0.3f,0.3f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing((float)96/255, 0.0f,(float)128/255, (float)32/255, 160,0,192,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_MODE_LIGHT]);
 
 	if(cur_mode!=mode_height && view_height)
 	glColor3f(1.0f,1.0f,1.0f);
 	else if(!view_height && cur_mode!=mode_height)glColor3f(0.3f,0.3f,0.3f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing((float)160/255, (float)32/255, (float)192/255, (float)64/255, 192,0,224,32);
-
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_MODE_HEIGHT]);
 
 	if(cur_mode!=mode_map)
 	glColor3f(1.0f,1.0f,1.0f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing((float)128/255, 0.0f, (float)160/255, (float)32/255, 224,0,256,32);
-
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_MODE_MAP]);
 
 	if(cur_tool!=tool_select)
 	glColor3f(1.0f,1.0f,1.0f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing(0, (float)32/255, (float)32/255, (float)64/255, 256,0,288,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_TOOL_SELECT]);
 
 	if(cur_tool!=tool_clone)
 	glColor3f(1.0f,1.0f,1.0f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing((float)32/255, (float)32/255, (float)64/255, (float)64/255, 288,0,320,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_TOOL_CLONE]);
 
 	if(cur_tool!=tool_new)
 	glColor3f(1.0f,1.0f,1.0f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing((float)224/255, 0.0f, (float)256/255, (float)32/255, 320,0,352,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_TOOL_NEW]);
 
 	if(cur_tool!=tool_kill)
 	glColor3f(1.0f,1.0f,1.0f);
 	else glColor3f(0.0f,1.0f,1.0f);
-	draw_2d_thing((float)192/255, 0.0f, (float)224/255, (float)32/255, 352,0,384,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_TOOL_KILL]);
 
 	glColor3f(1.0f,1.0f,1.0f);
-	//save
-	draw_2d_thing((float)64/255, (float)32/255, (float)96/255, (float)64/255, 384,0,416,32);
-
-	//open
-	draw_2d_thing((float)96/255, (float)32/255, (float)128/255, (float)64/255, 416,0,448,32);
-
-	//new
-	draw_2d_thing((float)128/255, (float)32/255, (float)160/255, (float)64/255, 448,0,480,32);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_SAVE_MAP]);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_OPEN_MAP]);
+	draw_toolbar_button(toolbar[TOOLBAR_BUTTON_NEW_MAP]);
 
 	glEnd();
 
-	if (show_toolbar_tooltip)
+	if (toolbar_mouseover && view_tooltips)
 	{
 		glColor3f(1.0f, 1.0f, 1.0f);
-		draw_string(mouse_x + TOOLTIP_MOUSE_X_SHIFT, mouse_y + TOOLTIP_MOUSE_Y_SHIFT, (const unsigned char *) tooltip_text, 1);
+		draw_string(mouse_x + TOOLTIP_MOUSE_X_SHIFT, mouse_y + TOOLTIP_MOUSE_Y_SHIFT, (const unsigned char *) toolbar_tooltip_text, 1);
 	}
 }
 

--- a/map_editor/interface.c
+++ b/map_editor/interface.c
@@ -294,6 +294,12 @@ void draw_toolbar()
 	draw_2d_thing((float)128/255, (float)32/255, (float)160/255, (float)64/255, 448,0,480,32);
 
 	glEnd();
+
+	if (show_toolbar_tooltip)
+	{
+		glColor3f(1.0f, 1.0f, 1.0f);
+		draw_string(mouse_x + TOOLTIP_MOUSE_X_SHIFT, mouse_y + TOOLTIP_MOUSE_Y_SHIFT, (const unsigned char *) tooltip_text, 1);
+	}
 }
 
 void draw_3d_obj_info()

--- a/map_editor/interface.h
+++ b/map_editor/interface.h
@@ -33,8 +33,43 @@ extern "C"
 #define TOOLTIP_MOUSE_X_SHIFT 10
 #define TOOLTIP_MOUSE_Y_SHIFT 10
 
-extern int show_toolbar_tooltip;
-extern char tooltip_text[MAX_TOOLTIP_SIZE];
+#define TOOLBAR_BUTTON_WIDTH 32
+#define TOOLBAR_BUTTON_HEIGHT 32
+
+#define TOOLBAR_MAX_BUTTON 15
+
+#define TOOLBAR_BUTTON_MODE_TILE 0
+#define TOOLBAR_BUTTON_MODE_2D 1
+#define TOOLBAR_BUTTON_MODE_3D 2
+#define TOOLBAR_BUTTON_MODE_PARTICLES 3
+#define TOOLBAR_BUTTON_MODE_EYE_CANDY 4
+#define TOOLBAR_BUTTON_MODE_LIGHT 5
+#define TOOLBAR_BUTTON_MODE_HEIGHT 6
+#define TOOLBAR_BUTTON_MODE_MAP 7
+#define TOOLBAR_BUTTON_TOOL_SELECT 8
+#define TOOLBAR_BUTTON_TOOL_CLONE 9
+#define TOOLBAR_BUTTON_TOOL_NEW 10
+#define TOOLBAR_BUTTON_TOOL_KILL 11
+#define TOOLBAR_BUTTON_SAVE_MAP 12
+#define TOOLBAR_BUTTON_OPEN_MAP 13
+#define TOOLBAR_BUTTON_NEW_MAP 14
+
+typedef struct {
+	float u_start;
+	float v_start;
+	float u_end;
+	float v_end;
+	int x_start;
+	int y_start;
+	int x_end;
+	int y_end;
+	const char * tooltip;
+} toolbar_button;
+
+extern toolbar_button toolbar[];
+
+extern int toolbar_mouseover;
+extern char toolbar_tooltip_text[MAX_TOOLTIP_SIZE];
 
 extern int mouse_x;
 extern int mouse_y;

--- a/map_editor/interface.h
+++ b/map_editor/interface.h
@@ -29,6 +29,13 @@ extern "C"
 #define tool_select 2
 #define tool_clone 3
 
+#define MAX_TOOLTIP_SIZE 256
+#define TOOLTIP_MOUSE_X_SHIFT 10
+#define TOOLTIP_MOUSE_Y_SHIFT 10
+
+extern int show_toolbar_tooltip;
+extern char tooltip_text[MAX_TOOLTIP_SIZE];
+
 extern int mouse_x;
 extern int mouse_y;
 extern int mouse_delta_x;

--- a/map_editor/mapedit.ini
+++ b/map_editor/mapedit.ini
@@ -32,6 +32,9 @@ when in minimap-mode.
 This setting decides if you should show the grid as default or not.
 #show_grid = 0
 
+This setting decides if you should show the tooltips as default or not.
+#show_tooltips = 1
+
 The following setting decides the time interval in minutes between when the map editor
 saves the map automatically to maps/Autosave.elm. If 0, it will not save the map automatically.
 #auto_save = 5


### PR DESCRIPTION
I was wondering if we could add tooltips to the map editor buttons, something like this.

I could try to rework the code a bit to prevent duplicating the "positions" of of the buttons if needed.