### PR TITLE
Fix DROP_ITEM message_length in quickbar

### DIFF
--- a/hud_quickbar_window.c
+++ b/hud_quickbar_window.c
@@ -391,7 +391,7 @@ static int	click_quickbar_handler(window_info *win, int mx, int my, Uint32 flags
 										str[0]=DROP_ITEM;
 										str[1]=item_list[i].pos;
 										*((Uint32 *)(str+2))=item_list[i].quantity;
-										my_tcp_send(my_socket, str, 4);
+										my_tcp_send(my_socket, str, 6);
 										do_drop_item_sound();
 										return 1;
 									} else if(qb_action_mode==ACTION_LOOK)


### PR DESCRIPTION
Fix DROP_ITEM message_length in quickbar

When doing a ctlr + left click to drop all from the quick bar the the **DROP_ITEM** message length was set to 4 causing item quantity to misbehave.
The fix sets the **DROP_ITEM** message length to 6 like all the other DROP_ITEM messages in the code.

State before drop all from quick bar (ctrl + left click)
![inventory-quickbar-before-drop-all-in-quickbar](https://user-images.githubusercontent.com/3391955/103544044-bf3acb00-4e9f-11eb-9ccf-db9975f80e77.png)
State after drop all from quick bar (ctrl + left click)
![inventory-quickbar-bag-after-drop-all-in-quickbar](https://user-images.githubusercontent.com/3391955/103544053-c2ce5200-4e9f-11eb-9d95-315ff0f68abb.png)
