### PR TITLE
Fix valgrind alert about lost block by freeing el_gl_window related stuff properly

### DIFF
--- a/gl_init.c
+++ b/gl_init.c
@@ -950,7 +950,8 @@ int print_gl_errors(const char *file, int line)
 	return anyErr;
 }
 
-void gl_window_cleanup() {
+void gl_window_cleanup(void)
+{
 	if (el_gl_window != NULL)
 	{
 		SDL_DestroyWindow(el_gl_window);

--- a/gl_init.c
+++ b/gl_init.c
@@ -950,3 +950,15 @@ int print_gl_errors(const char *file, int line)
 	return anyErr;
 }
 
+void gl_window_cleanup() {
+	if (el_gl_window != NULL)
+	{
+		SDL_DestroyWindow(el_gl_window);
+		el_gl_window = NULL;
+	}
+	if (icon_bmp != NULL)
+	{
+		SDL_FreeSurface(icon_bmp);
+		icon_bmp = NULL;
+	}
+}

--- a/gl_init.h
+++ b/gl_init.h
@@ -130,6 +130,15 @@ void set_client_window_size(int width, int height); /*!< set the window size as 
 int print_gl_errors(const char *file, int line);
 
 /*!
+ * \ingroup video
+ * \brief   cleanup gl_window
+ *
+ *      Clean up gl_window related stuff
+ *
+ */
+void gl_window_cleanup(void);
+
+/*!
  * \name CHECK_GL_ERRORS macro - only done if DEBUG or OPENGL_TRACE defined
  */
 /*! @{ */

--- a/main.c
+++ b/main.c
@@ -372,6 +372,9 @@ int start_rendering()
 	LOG_INFO("cursors_cleanup()");
 	cursors_cleanup();
 
+	LOG_INFO("gl_window_cleanup()");
+	gl_window_cleanup();
+
 	LOG_INFO("SDL_Quit()");
 	SDL_Quit();
 	LOG_INFO("cleanup_mem()");


### PR DESCRIPTION
Fix valgrind alert about lost block by freeing el_gl_window related stuff properly

```
==67234== 2,376 (96 direct, 2,280 indirect) bytes in 1 blocks are definitely lost in loss record 174 of 186
==67234==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==67234==    by 0x48ED351: ??? (in /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0.14.0)
==67234==    by 0x4926CD0: ??? (in /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0.14.0)
==67234==    by 0x491EF73: ??? (in /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0.14.0)
==67234==    by 0x17CD9C: load_window_icon (gl_init.c:78)
==67234==    by 0x17CD9C: init_video (gl_init.c:314)
==67234==    by 0x187193: init_stuff (init.c:859)
==67234==    by 0x1A82D8: main (main.c:555)
```