### PR TITLE
Map sounds

### DIFF
--- a/dev-data-files/sound/mapsfx_c1.xml
+++ b/dev-data-files/sound/mapsfx_c1.xml
@@ -1,4 +1,4 @@
-<map id="162" name="Isla Prima">
+<map file_name="./maps/startmap.elm" name="Isla Prima">
 	<boundary_def>
 		<background>Forest02</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -8,21 +8,21 @@
 		<background>Forest Night01</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>		
+	</boundary_def>
 	<walk_boundary_def location="IP Docks">
-	  <sound>Wood 2Foot</sound>
-	  <point1>12,11</point1>
-	  <point2>12,35</point2>
-	  <point3>35,35</point3>
-	  <point4>35,11</point4>
- 	</walk_boundary_def>	
+		<sound>Wood 2Foot</sound>
+		<point1>12,11</point1>
+		<point2>12,35</point2>
+		<point3>35,35</point3>
+		<point4>35,11</point4>
+	</walk_boundary_def>
 	<walk_boundary_def location="IP Bridge">
-	  <sound>Stone 2Foot</sound>
-	  <point1>137,68</point1>
-	  <point2>138,86</point2>
-	  <point3>143,86</point3>
-	  <point4>142,68</point4>
- 	</walk_boundary_def>
+		<sound>Stone 2Foot</sound>
+		<point1>137,68</point1>
+		<point2>138,86</point2>
+		<point3>143,86</point3>
+		<point4>142,68</point4>
+	</walk_boundary_def>
 	<boundary_def>
 		<background>Lake01</background>
 		<point1>42,78</point1>
@@ -37,7 +37,6 @@
 		<point3>170,84</point3>
 		<point4>170,48</point4>
 	</boundary_def>
-
 	<boundary_def>
 		<background>Lake01</background>
 		<point1>10,17</point1>
@@ -51,7 +50,7 @@
 		<point2>0,191</point2>
 		<point3>34,191</point3>
 		<point4>15,0</point4>
-	</boundary_def>	
+	</boundary_def>
 	<boundary_def>
 		<background>Waves01</background>
 		<point1>25,175</point1>
@@ -79,9 +78,9 @@
 		<point2>17,38</point2>
 		<point3>191,38</point3>
 		<point4>191,0</point4>
-	</boundary_def>		
+	</boundary_def>
 </map>
-<map id="132" name="Whitestone">
+<map file_name="./maps/map2.elm" name="Whitestone">
 	<boundary_def>
 		<background>Forest02</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -91,69 +90,69 @@
 		<background>Forest Night01</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>	
+	</boundary_def>
 	<walk_boundary_def location="Lakeside Docks">
-	  <sound>Wood 2Foot</sound>
-	  <point1>695,133</point1>
-	  <point2>695,184</point2>
-	  <point3>707,184</point3>
-	  <point4>736,134</point4>
- 	</walk_boundary_def>
+		<sound>Wood 2Foot</sound>
+		<point1>695,133</point1>
+		<point2>695,184</point2>
+		<point3>707,184</point3>
+		<point4>736,134</point4>
+	</walk_boundary_def>
 	<walk_boundary_def location="Lakeside Docks2">
-	  <sound>Wood 2Foot</sound>
-	  <point1>612,174</point1>
-	  <point2>653,191</point2>
- 	</walk_boundary_def>
+		<sound>Wood 2Foot</sound>
+		<point1>612,174</point1>
+		<point2>653,191</point2>
+	</walk_boundary_def>
 	<walk_boundary_def location="Lakeside Docks2">
-	  <sound>Wood 2Foot</sound>
-	  <point1>654,174</point1>
-	  <point2>658,179</point2>
- 	</walk_boundary_def> 	
+		<sound>Wood 2Foot</sound>
+		<point1>654,174</point1>
+		<point2>658,179</point2>
+	</walk_boundary_def>
 	<walk_boundary_def location="Lakeside Island Bridge">
-	  <sound>Stone 2Foot</sound>
-	  <point1>632,218</point1>
-	  <point2>632,231</point2>
-	  <point3>636,231</point3>
-	  <point4>636,218</point4>
- 	</walk_boundary_def>
+		<sound>Stone 2Foot</sound>
+		<point1>632,218</point1>
+		<point2>632,231</point2>
+		<point3>636,231</point3>
+		<point4>636,218</point4>
+	</walk_boundary_def>
 	<walk_boundary_def location="Lakeside Bridge2">
-	  <sound>Stone 2Foot</sound>
-	  <point1>714,31</point1>
-	  <point2>714,58</point2>
-	  <point3>718,58</point3>
-	  <point4>718,31</point4>
- 	</walk_boundary_def>
+		<sound>Stone 2Foot</sound>
+		<point1>714,31</point1>
+		<point2>714,58</point2>
+		<point3>718,58</point3>
+		<point4>718,31</point4>
+	</walk_boundary_def>
 	<walk_boundary_def location="Vermor Castle Bridge">
-	  <sound>Stone 2Foot</sound>
-	  <point1>599,428</point1>
-	  <point2>599,432</point2>
-	  <point3>613,432</point3>
-	  <point4>613,428</point4>
- 	</walk_boundary_def>
+		<sound>Stone 2Foot</sound>
+		<point1>599,428</point1>
+		<point2>599,432</point2>
+		<point3>613,432</point3>
+		<point4>613,428</point4>
+	</walk_boundary_def>
 	<walk_boundary_def location="Bridge to PL">
-	  <sound>Stone 2Foot</sound>
-	  <point1>33,562</point1>
-	  <point2>60,566</point2>
- 	</walk_boundary_def> 	
+		<sound>Stone 2Foot</sound>
+		<point1>33,562</point1>
+		<point2>60,566</point2>
+	</walk_boundary_def>
 	<walk_boundary_def location="Tirnwood pond">
-	  <sound>Dirt 2Foot</sound>
-	  <point1>234,324</point1>
-	  <point2>234,343</point2>
-	  <point3>257,343</point3>
-	  <point4>257,330</point4>
- 	</walk_boundary_def>   	
+		<sound>Dirt 2Foot</sound>
+		<point1>234,324</point1>
+		<point2>234,343</point2>
+		<point3>257,343</point3>
+		<point4>257,330</point4>
+	</walk_boundary_def>
 	<walk_boundary_def location="Island to C2">
-	  <sound>Dirt 2Foot</sound>
-	  <point1>390,13</point1>
-	  <point2>390,47</point2>
-	  <point3>407,45</point3>
-	  <point4>433,21</point4>
- 	</walk_boundary_def>
+		<sound>Dirt 2Foot</sound>
+		<point1>390,13</point1>
+		<point2>390,47</point2>
+		<point3>407,45</point3>
+		<point4>433,21</point4>
+	</walk_boundary_def>
 	<boundary_def location="Beehive in grahm's">
 		<background>Beehive</background>
 		<point1>101,202</point1>
 		<point2>109,209</point2>
-	</boundary_def> 	
+	</boundary_def>
 	<boundary_def location="Boats">
 		<background>Waves01</background>
 		<point1>685,116</point1>
@@ -183,8 +182,7 @@
 		<point4>528,9</point4>
 	</boundary_def>
 </map>
-
-<map id="134" name="White Stone insides">
+<map file_name="./maps/map2_insides.elm" name="White Stone insides">
 	<walk_boundary_def location="Round walkway in aluwen's temple">
 		<sound>Stone 2Foot</sound>
 		<point1>23,234</point1>
@@ -194,7 +192,7 @@
 		<sound>Stone 2Foot</sound>
 		<point1>29,264</point1>
 		<point2>59,281</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 	<walk_boundary_def location="grassy part in aluwen's temp">
 		<sound>Grass 2Foot</sound>
 		<point1>15,271</point1>
@@ -204,27 +202,24 @@
 		<sound>Grass 2Foot</sound>
 		<point1>27,281</point1>
 		<point2>58,299</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 	<walk_boundary_def location="Bridge over stone pit">
 		<sound>Stone 2Foot</sound>
 		<point1>119,252</point1>
 		<point2>120, 269</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Around ladder">
 		<sound>Dirt 2Foot</sound>
 		<point1>199,148</point1>
 		<point2>206,154</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Around hole in ground">
 		<sound>Dirt 2Foot</sound>
 		<point1>357,246</point1>
 		<point2>364,254</point2>
 	</walk_boundary_def>
 </map>
-
-<map id="136" name="Desert Pines">
+<map file_name="./maps/map3.elm" name="Desert Pines">
 	<boundary_def>
 		<background>Forest02</background>
 		<point1>0,268</point1>
@@ -262,7 +257,6 @@
 		<point3>44,193</point3>
 		<point4>144,94</point4>
 	</boundary_def>
-
 	<boundary_def>
 		<background>Water01</background>
 		<point1>289,92</point1>
@@ -270,7 +264,6 @@
 		<point3>375,150</point3>
 		<point4>375,92</point4>
 	</boundary_def>
-	
 	<walk_boundary_def location="docks">
 		<sound>Wood 2Foot</sound>
 		<point1>348,312</point1>
@@ -285,7 +278,7 @@
 		<sound>Stone 2Foot</sound>
 		<point1>49,235</point1>
 		<point2>70,250</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 	<walk_boundary_def location="dirt depression">
 		<sound>Dirt 2Foot</sound>
 		<point1>18,138</point1>
@@ -296,7 +289,7 @@
 		<point1>31,70</point1>
 		<point2>24,112</point2>
 		<point3>67,140</point3>
-		<point4>65,69</point4>		
+		<point4>65,69</point4>
 	</walk_boundary_def>
 	<walk_boundary_def location="dirt path through water">
 		<sound>Dirt 2Foot</sound>
@@ -317,24 +310,21 @@
 		<sound>Stone 2Foot</sound>
 		<point1>273,204</point1>
 		<point2>277,217</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-
-<map id="137" name="Desert Pines Insides">
+<map file_name="./maps/map3_insides.elm" name="Desert Pines Insides">
 	<walk_boundary_def location="Around tree">
 		<sound>Dirt 2Foot</sound>
 		<point1>92,165</point1>
 		<point2>104,176</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Alchemy school">
 		<sound>Dirt 2Foot</sound>
 		<point1>148,93</point1>
 		<point2>180,25</point2>
 	</walk_boundary_def>
 </map>
-
-<map id="139" name="Tirnym">
+<map file_name="./maps/map4f.elm" name="Tirnym">
 	<boundary_def>
 		<background>Forest02</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -344,37 +334,37 @@
 		<background>Forest Night01</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>	
+	</boundary_def>
 	<walk_boundary_def location="Magic school entrance">
-	  <sound>Stone 2Foot</sound>
-	  <point1>10,84</point1>
-	  <point2>35,118</point2>
-	  <point3>40,118</point3>
-	  <point4>40,84</point4>
- 	</walk_boundary_def>
-	<boundary_def> 	
-	<background>Water01</background>
-	  <point1>0,22</point1>
-	  <point2>0,155</point2>
-	  <point3>31,155</point3>
-	  <point4>52,22</point4>
+		<sound>Stone 2Foot</sound>
+		<point1>10,84</point1>
+		<point2>35,118</point2>
+		<point3>40,118</point3>
+		<point4>40,84</point4>
+	</walk_boundary_def>
+	<boundary_def>
+		<background>Water01</background>
+		<point1>0,22</point1>
+		<point2>0,155</point2>
+		<point3>31,155</point3>
+		<point4>52,22</point4>
 	</boundary_def>
-	<boundary_def>	
-	<background>Water01</background>
-	  <point1>53,22</point1>
-	  <point2>53,38</point2>
-	  <point3>166,38</point3>
-	  <point4>166,22</point4>
+	<boundary_def>
+		<background>Water01</background>
+		<point1>53,22</point1>
+		<point2>53,38</point2>
+		<point3>166,38</point3>
+		<point4>166,22</point4>
 	</boundary_def>
-	<boundary_def>	
-	<background>Water01</background>
-	  <point1>146,22</point1>
-	  <point2>146,114</point2>
-	  <point3>176,191</point3>
-	  <point4>191,58</point4>
-	</boundary_def> 	
+	<boundary_def>
+		<background>Water01</background>
+		<point1>146,22</point1>
+		<point2>146,114</point2>
+		<point3>176,191</point3>
+		<point4>191,58</point4>
+	</boundary_def>
 </map>
-<map id="138" name="Tirnym past">
+<map file_name="./maps/map4_past.elm" name="Tirnym past">
 	<boundary_def>
 		<background>Forest02</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -384,37 +374,37 @@
 		<background>Forest Night01</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>	
+	</boundary_def>
 	<walk_boundary_def location="Magic school entrance">
-	  <sound>Stone 2Foot</sound>
-	  <point1>10,84</point1>
-	  <point2>35,118</point2>
-	  <point3>40,118</point3>
-	  <point4>40,84</point4>
- 	</walk_boundary_def>
-	<boundary_def> 	
-	<background>Water01</background>
-	  <point1>0,22</point1>
-	  <point2>0,155</point2>
-	  <point3>31,155</point3>
-	  <point4>52,22</point4>
+		<sound>Stone 2Foot</sound>
+		<point1>10,84</point1>
+		<point2>35,118</point2>
+		<point3>40,118</point3>
+		<point4>40,84</point4>
+	</walk_boundary_def>
+	<boundary_def>
+		<background>Water01</background>
+		<point1>0,22</point1>
+		<point2>0,155</point2>
+		<point3>31,155</point3>
+		<point4>52,22</point4>
 	</boundary_def>
-	<boundary_def>	
-	<background>Water01</background>
-	  <point1>53,22</point1>
-	  <point2>53,38</point2>
-	  <point3>166,38</point3>
-	  <point4>166,22</point4>
+	<boundary_def>
+		<background>Water01</background>
+		<point1>53,22</point1>
+		<point2>53,38</point2>
+		<point3>166,38</point3>
+		<point4>166,22</point4>
 	</boundary_def>
-	<boundary_def>	
-	<background>Water01</background>
-	  <point1>146,22</point1>
-	  <point2>146,114</point2>
-	  <point3>176,191</point3>
-	  <point4>191,58</point4>
-	</boundary_def> 	
+	<boundary_def>
+		<background>Water01</background>
+		<point1>146,22</point1>
+		<point2>146,114</point2>
+		<point3>176,191</point3>
+		<point4>191,58</point4>
+	</boundary_def>
 </map>
-<map id="140" name="Valley of the Dwarves">
+<map file_name="./maps/map5nf.elm" name="Valley of the Dwarves">
 	<boundary_def>
 		<background>Meadow01</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -424,65 +414,65 @@
 		<background>Forest Night01</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>	
+	</boundary_def>
 	<walk_boundary_def location="VOTD Docks">
-	  <sound>Wood 2Foot</sound>
-	  <point1>70,157</point1>
-	  <point2>58,186</point2>
-	  <point3>70,191</point3>
-	  <point4>81,165</point4>
- 	</walk_boundary_def>	
+		<sound>Wood 2Foot</sound>
+		<point1>70,157</point1>
+		<point2>58,186</point2>
+		<point3>70,191</point3>
+		<point4>81,165</point4>
+	</walk_boundary_def>
 	<walk_boundary_def location="VOTD Docks2">
-	  <sound>Wood 2Foot</sound>
-	  <point1>55,168</point1>
-	  <point2>50,180</point2>
-	  <point3>59,183</point3>
-	  <point4>63,172</point4>
- 	</walk_boundary_def>
+		<sound>Wood 2Foot</sound>
+		<point1>55,168</point1>
+		<point2>50,180</point2>
+		<point3>59,183</point3>
+		<point4>63,172</point4>
+	</walk_boundary_def>
 	<walk_boundary_def location="VOTD log crossing">
-	  <sound>Dirt 2Foot</sound>
-	  <point1>96,121</point1>
-	  <point2>96,138</point2>
-	  <point3>113,138</point3>
-	  <point4>113,121</point4>
- 	</walk_boundary_def>
+		<sound>Dirt 2Foot</sound>
+		<point1>96,121</point1>
+		<point2>96,138</point2>
+		<point3>113,138</point3>
+		<point4>113,121</point4>
+	</walk_boundary_def>
 	<boundary_def>
-	<background>Water01</background>
-	  <point1>59,0</point1>
-	  <point2>59,113</point2>
-	  <point3>98,113</point3>
-	  <point4>98,0</point4>
+		<background>Water01</background>
+		<point1>59,0</point1>
+		<point2>59,113</point2>
+		<point3>98,113</point3>
+		<point4>98,0</point4>
 	</boundary_def>
-	<boundary_def>	
-	<background>Water01</background>
-	  <point1>89,114</point1>
-	  <point2>89,146</point2>
-	  <point3>116,146</point3>
-	  <point4>116,114</point4>
+	<boundary_def>
+		<background>Water01</background>
+		<point1>89,114</point1>
+		<point2>89,146</point2>
+		<point3>116,146</point3>
+		<point4>116,114</point4>
 	</boundary_def>
-	<boundary_def>	
-	<background>Water01</background>
-	  <point1>73,147</point1>
-	  <point2>57,191</point2>
-	  <point3>111,191</point3>
-	  <point4>111,147</point4>
+	<boundary_def>
+		<background>Water01</background>
+		<point1>73,147</point1>
+		<point2>57,191</point2>
+		<point3>111,191</point3>
+		<point4>111,147</point4>
 	</boundary_def>
-	<boundary_def>	
-	<background>Water01</background>
-	  <point1>73,147</point1>
-	  <point2>57,191</point2>
-	  <point3>111,191</point3>
-	  <point4>111,147</point4>
+	<boundary_def>
+		<background>Water01</background>
+		<point1>73,147</point1>
+		<point2>57,191</point2>
+		<point3>111,191</point3>
+		<point4>111,147</point4>
 	</boundary_def>
-	<boundary_def>	
-	<background>Water01</background>
-	  <point1>31,172</point1>
-	  <point2>31,191</point2>
-	  <point3>155,191</point3>
-	  <point4>155,172</point4>
-	</boundary_def>		
+	<boundary_def>
+		<background>Water01</background>
+		<point1>31,172</point1>
+		<point2>31,191</point2>
+		<point3>155,191</point3>
+		<point4>155,172</point4>
+	</boundary_def>
 </map>
-<map id="124" name="Nordcarn">
+<map file_name="./maps/map12.elm" name="Nordcarn">
 	<boundary_def>
 		<background>Meadow01</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -494,14 +484,14 @@
 		<is_default>1</is_default>
 	</boundary_def>
 	<walk_boundary_def location="Bridge">
-	  <sound>Stone 2Foot</sound>
-	  <point1>47,150</point1>
-	  <point2>47,160</point2>
-	  <point3>77,157</point3>
-	  <point4>77,152</point4>
- 	</walk_boundary_def>	
+		<sound>Stone 2Foot</sound>
+		<point1>47,150</point1>
+		<point2>47,160</point2>
+		<point3>77,157</point3>
+		<point4>77,152</point4>
+	</walk_boundary_def>
 </map>
-<map id="125" name="Nordcarn cave">
+<map file_name="./maps/map12_cave.elm" name="Nordcarn cave">
 	<walk_boundary_def location="northern dock">
 		<sound>Wood 2Foot</sound>
 		<point1>148,138</point1>
@@ -513,7 +503,7 @@
 		<point2>67,104</point2>
 	</walk_boundary_def>
 </map>
-<map id="129" name="Kilaran Field">
+<map file_name="./maps/map14f.elm" name="Kilaran Field">
 	<boundary_def>
 		<background>Meadow01</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -524,18 +514,18 @@
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
-	<walk_boundary_def location="Wooden footbridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>75,102</point1>
-	  <point2>79,107</point2>
- 	</walk_boundary_def>
-	<walk_boundary_def location="Stone steps leading to tower">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>74,67</point1>
-	  <point2>80,72</point2>
- 	</walk_boundary_def>	 	
+	<walk_boundary_def location="Wooden footbridge">
+		<sound>Wood 2Foot</sound>
+		<point1>75,102</point1>
+		<point2>79,107</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone steps leading to tower">
+		<sound>Stone 2Foot</sound>
+		<point1>74,67</point1>
+		<point2>80,72</point2>
+	</walk_boundary_def>
 </map>
-<map id="126" name="South Kilaran Field">
+<map file_name="./maps/map13.elm" name="South Kilaran Field">
 	<boundary_def>
 		<background>Meadow01</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -546,89 +536,79 @@
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
-	<walk_boundary_def location="Bridge">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>119,73</point1>
-	  <point2>140,95</point2>
- 	</walk_boundary_def>	
+	<walk_boundary_def location="Bridge">
+		<sound>Stone 2Foot</sound>
+		<point1>119,73</point1>
+		<point2>140,95</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="127" name="South Kilaran Field inside carmien manor">
-<walk_boundary_def location="Wooden walkway 1">
-<sound>Wood 2Foot</sound>
-<point1>95,136</point1>
-<point2>108,137</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden walkway 2">
-<sound>Wood 2Foot</sound>
-<point1>95,126</point1>
-<point2>108,127</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden platform 1">
-<sound>Wood 2Foot</sound>
-<point1>74,30</point1>
-<point2>83,41</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden platform 2">
-<sound>Wood 2Foot</sound>
-<point1>108,30</point1>
-<point2>117,41</point2>
-</walk_boundary_def>
+<map file_name="./maps/map13_castle.elm" name="South Kilaran Field inside carmien manor">
+	<walk_boundary_def location="Wooden walkway 1">
+		<sound>Wood 2Foot</sound>
+		<point1>95,136</point1>
+		<point2>108,137</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden walkway 2">
+		<sound>Wood 2Foot</sound>
+		<point1>95,126</point1>
+		<point2>108,127</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden platform 1">
+		<sound>Wood 2Foot</sound>
+		<point1>74,30</point1>
+		<point2>83,41</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden platform 2">
+		<sound>Wood 2Foot</sound>
+		<point1>108,30</point1>
+		<point2>117,41</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="130" name="Tahraji Desert">
+<map file_name="./maps/map15f.elm" name="Tahraji Desert">
 	<boundary_def>
 		<background>Desert01</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
-	<walk_boundary_def location="summoning">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>135,250</point1>
-	  <point2>171,283</point2>
- 	</walk_boundary_def>	
+	<walk_boundary_def location="summoning">
+		<sound>Stone 2Foot</sound>
+		<point1>135,250</point1>
+		<point2>171,283</point2>
+	</walk_boundary_def>
 </map>
-<map id="131" name="Tahraji Desert cave">
-<walk_boundary_def location="Wood bridge over water">
-<sound>Wood 2Foot</sound>
-<point1>13,49</point1>
-<point2>28,50</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone part of bridge1">
-<sound>Stone 2Foot</sound>
-<point1>71,75</point1>
-<point2>77,75</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden part of bridge2">
-<sound>Wood 2Foot</sound>
-<point1>78,75</point1>
-<point2>89,75</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone part of bridge3">
-<sound>Stone 2Foot</sound>
-<point1>90,75</point1>
-<point2>95,75</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone bridge over lava">
-<sound>Stone 2Foot</sound>
-<point1>58,130</point1>
-<point2>59,140</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stones over lava">
-<sound>Stone 2Foot</sound>
-<point1>60,112</point1>
-<point2>61,122</point2>
-</walk_boundary_def>
+<map file_name="./maps/map15_cave.elm" name="Tahraji Desert cave">
+	<walk_boundary_def location="Wood bridge over water">
+		<sound>Wood 2Foot</sound>
+		<point1>13,49</point1>
+		<point2>28,50</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone part of bridge1">
+		<sound>Stone 2Foot</sound>
+		<point1>71,75</point1>
+		<point2>77,75</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden part of bridge2">
+		<sound>Wood 2Foot</sound>
+		<point1>78,75</point1>
+		<point2>89,75</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone part of bridge3">
+		<sound>Stone 2Foot</sound>
+		<point1>90,75</point1>
+		<point2>95,75</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone bridge over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>58,130</point1>
+		<point2>59,140</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stones over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>60,112</point1>
+		<point2>61,122</point2>
+	</walk_boundary_def>
 </map>
-<map id="118" name="Tarsengaard">
+<map file_name="./maps/map11.elm" name="Tarsengaard">
 	<boundary_def>
 		<background>Forest02</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -639,144 +619,137 @@
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
-	<walk_boundary_def location="dock to ship">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>129,288</point1>
-	  <point2>143,314</point2>
- 	</walk_boundary_def>
-	<walk_boundary_def location="wall leading to docks">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>129,189</point1>
-	  <point2>133,287</point2>
- 	</walk_boundary_def>
-	<walk_boundary_def location="wall">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>134,189</point1>
-	  <point2>157,193</point2>
- 	</walk_boundary_def>
-	<walk_boundary_def location="wall">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>157,174</point1>
-	  <point2>161,206</point2>
- 	</walk_boundary_def>
-	<walk_boundary_def location="stairs from wall">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>157,207</point1>
-	  <point2>162,227</point2>
- 	</walk_boundary_def>
-	<walk_boundary_def location="stairs from wall">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>163,222</point1>
-	  <point2>173,227</point2>
- 	</walk_boundary_def>
-	<walk_boundary_def location="wall">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>161,174</point1>
-	  <point2>251,178</point2>
- 	</walk_boundary_def>
-	<walk_boundary_def location="stairs from wall">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>185,179</point1>
-	  <point2>189,188</point2>
- 	</walk_boundary_def>
-	<walk_boundary_def location="stairs from wall">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>224,179</point1>
-	  <point2>238,184</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="stone around craft school">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>252,190</point1>
-	  <point2>266,207</point2>
- 	</walk_boundary_def>	
- 	<walk_boundary_def location="stone around craft school">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>267,190</point1>
-	  <point2>275,196</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="dock at craft school">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>267,213</point1>
-	  <point2>278,218</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="stone around magic school">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>173,304</point1>
-	  <point2>208,334</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="stone around magic school">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>186,294</point1>
-	  <point2>201,303</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="spot in middle of roanof">	
-	  <sound>Dirt 2Foot</sound>
-	  <point1>294,348</point1>
-	  <point2>305,359</point2>
- 	</walk_boundary_def>  
- 	<walk_boundary_def location="small dock on roanof">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>342,307</point1>
-	  <point2>347,308</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="ground depression">	
-	  <sound>Dirt 2Foot</sound>
-	  <point1>36,276</point1>
-	  <point2>47,299</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="ground depression outside of mine">	
-	  <sound>Dirt 2Foot</sound>
-	  <point1>38,49</point1>
-	  <point2>87,78</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="rocky area">	
-	  <sound>Dirt 2Foot</sound>
-	  <point1>223,18</point1>
-	  <point2>281,47</point2>
- 	</walk_boundary_def> 	 	
+	<walk_boundary_def location="dock to ship">
+		<sound>Wood 2Foot</sound>
+		<point1>129,288</point1>
+		<point2>143,314</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wall leading to docks">
+		<sound>Stone 2Foot</sound>
+		<point1>129,189</point1>
+		<point2>133,287</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wall">
+		<sound>Stone 2Foot</sound>
+		<point1>134,189</point1>
+		<point2>157,193</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wall">
+		<sound>Stone 2Foot</sound>
+		<point1>157,174</point1>
+		<point2>161,206</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stairs from wall">
+		<sound>Stone 2Foot</sound>
+		<point1>157,207</point1>
+		<point2>162,227</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stairs from wall">
+		<sound>Stone 2Foot</sound>
+		<point1>163,222</point1>
+		<point2>173,227</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wall">
+		<sound>Stone 2Foot</sound>
+		<point1>161,174</point1>
+		<point2>251,178</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stairs from wall">
+		<sound>Stone 2Foot</sound>
+		<point1>185,179</point1>
+		<point2>189,188</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stairs from wall">
+		<sound>Stone 2Foot</sound>
+		<point1>224,179</point1>
+		<point2>238,184</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stone around craft school">
+		<sound>Stone 2Foot</sound>
+		<point1>252,190</point1>
+		<point2>266,207</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stone around craft school">
+		<sound>Stone 2Foot</sound>
+		<point1>267,190</point1>
+		<point2>275,196</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="dock at craft school">
+		<sound>Wood 2Foot</sound>
+		<point1>267,213</point1>
+		<point2>278,218</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stone around magic school">
+		<sound>Stone 2Foot</sound>
+		<point1>173,304</point1>
+		<point2>208,334</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stone around magic school">
+		<sound>Stone 2Foot</sound>
+		<point1>186,294</point1>
+		<point2>201,303</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="spot in middle of roanof">
+		<sound>Dirt 2Foot</sound>
+		<point1>294,348</point1>
+		<point2>305,359</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="small dock on roanof">
+		<sound>Wood 2Foot</sound>
+		<point1>342,307</point1>
+		<point2>347,308</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="ground depression">
+		<sound>Dirt 2Foot</sound>
+		<point1>36,276</point1>
+		<point2>47,299</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="ground depression outside of mine">
+		<sound>Dirt 2Foot</sound>
+		<point1>38,49</point1>
+		<point2>87,78</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="rocky area">
+		<sound>Dirt 2Foot</sound>
+		<point1>223,18</point1>
+		<point2>281,47</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="119" name="Tarsengaard insides">
+<map file_name="./maps/map11_insides.elm" name="Tarsengaard insides">
 	<walk_boundary_def location="Wooden Dock with casket">
 		<sound>Wood 2Foot</sound>
 		<point1>201,354</point1>
 		<point2>205,359</point2>
 	</walk_boundary_def>
 </map>
-
-<map id="123" name="Tarsengaard crypt">
+<map file_name="./maps/map11_crypt.elm" name="Tarsengaard crypt">
 	<walk_boundary_def location="casket cover">
 		<sound>wood 2Foot</sound>
 		<point1>70,73</point1>
 		<point2>71,76</point2>
 	</walk_boundary_def>
 </map>
-
-<map id="120" name="Tarsengaard magic school">
+<map file_name="./maps/map11_insmsch.elm" name="Tarsengaard magic school">
 	<walk_boundary_def location="Dirt 1 in path">
 		<sound>Dirt 2Foot</sound>
 		<point1>358,74</point1>
 		<point2>363,31</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Stone pad 1">
 		<sound>Stone 2Foot</sound>
 		<point1>367,157</point1>
 		<point2>370,167</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Stone stair 1">
 		<sound>Stone 2Foot</sound>
 		<point1>356,187</point1>
 		<point2>370,194</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Stone stair 2">
 		<sound>Stone 2Foot</sound>
 		<point1>283,156</point1>
 		<point2>284,167</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="stone pad around">
 		<sound>Stone 2Foot</sound>
 		<point1>216,36</point1>
@@ -784,7 +757,6 @@
 		<point3>227,53</point3>
 		<point4>217,36</point4>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="stone pad 2 around">
 		<sound>Stone 2Foot</sound>
 		<point1>234,50</point1>
@@ -792,7 +764,6 @@
 		<point3>250,53</point3>
 		<point4>250,38</point4>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="stone pad 3 around">
 		<sound>Stone 2Foot</sound>
 		<point1>240,18</point1>
@@ -800,7 +771,6 @@
 		<point3>250,30</point3>
 		<point4>250,18</point4>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="stone pad 4 around">
 		<sound>Stone 2Foot</sound>
 		<point1>216,18</point1>
@@ -808,15 +778,13 @@
 		<point3>218,29</point3>
 		<point4>232,18</point4>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Stone around lava">
 		<sound>Stone 2Foot</sound>
 		<point1>13,342</point1>
 		<point2>31,355</point2>
 	</walk_boundary_def>
 </map>
-
-<map id="142" name="Portland">
+<map file_name="./maps/map6nf.elm" name="Portland">
 	<boundary_def>
 		<background>Forest03</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -827,122 +795,122 @@
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
- 	<walk_boundary_def location="small boats">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>109,17</point1>
-	  <point2>121,24</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="ship">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>138,19</point1>
-	  <point2>146,41</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="ship">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>144,48</point1>
-	  <point2>152,73</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="two ships and dock">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>174,54</point1>
-	  <point2>203,76</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="bridge in city">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>155,91</point1>
-	  <point2>168,95</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="suspension bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>94,248</point1>
-	  <point2>124,249</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="small dock">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>173,200</point1>
-	  <point2>182,209</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="bridge=">	
-	  <sound>Stone 2Foot</sound>
-	  <point1>191,228</point1>
-	  <point2>204,232</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wood outside of potion school">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>262,264</point1>
-	  <point2>284,273</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="dock and boat">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>31,183</point1>
-	  <point2>46,194</point2>
- 	</walk_boundary_def> 	 	
+	<walk_boundary_def location="small boats">
+		<sound>Wood 2Foot</sound>
+		<point1>109,17</point1>
+		<point2>121,24</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="ship">
+		<sound>Wood 2Foot</sound>
+		<point1>138,19</point1>
+		<point2>146,41</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="ship">
+		<sound>Wood 2Foot</sound>
+		<point1>144,48</point1>
+		<point2>152,73</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="two ships and dock">
+		<sound>Wood 2Foot</sound>
+		<point1>174,54</point1>
+		<point2>203,76</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="bridge in city">
+		<sound>Stone 2Foot</sound>
+		<point1>155,91</point1>
+		<point2>168,95</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="suspension bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>94,248</point1>
+		<point2>124,249</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="small dock">
+		<sound>Wood 2Foot</sound>
+		<point1>173,200</point1>
+		<point2>182,209</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="bridge=">
+		<sound>Stone 2Foot</sound>
+		<point1>191,228</point1>
+		<point2>204,232</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wood outside of potion school">
+		<sound>Wood 2Foot</sound>
+		<point1>262,264</point1>
+		<point2>284,273</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="dock and boat">
+		<sound>Wood 2Foot</sound>
+		<point1>31,183</point1>
+		<point2>46,194</point2>
+	</walk_boundary_def>
 </map>
-<map id="143" name="Portland insides">
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>162,313</point1>
-	  <point2>167,315</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>225,317</point1>
-	  <point2>227,330</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>231,305</point1>
-	  <point2>236,306</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>297,276</point1>
-	  <point2>299,282</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>276,314</point1>
-	  <point2>281,316</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>211,349</point1>
-	  <point2>215,254</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>366,271</point1>
-	  <point2>370,274</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>291,360</point1>
-	  <point2>302,362</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>60,318</point1>
-	  <point2>63,329</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>96,366</point1>
-	  <point2>124,366</point2>
- 	</walk_boundary_def>
- 	<walk_boundary_def location="wsc sewers bridge">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>123,367</point1>
-	  <point2>124,371</point2>
- 	</walk_boundary_def>  	
+<map file_name="./maps/map6nf_insides.elm" name="Portland insides">
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>162,313</point1>
+		<point2>167,315</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>225,317</point1>
+		<point2>227,330</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>231,305</point1>
+		<point2>236,306</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>297,276</point1>
+		<point2>299,282</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>276,314</point1>
+		<point2>281,316</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>211,349</point1>
+		<point2>215,254</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>366,271</point1>
+		<point2>370,274</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>291,360</point1>
+		<point2>302,362</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>60,318</point1>
+		<point2>63,329</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>96,366</point1>
+		<point2>124,366</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wsc sewers bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>123,367</point1>
+		<point2>124,371</point2>
+	</walk_boundary_def>
 </map>
-<map id="144" name="portland cave">
-<walk_boundary_def location="Bridge over water">
-<sound>Stone 2Foot</sound>
-<point1>36,150</point1>
-<point2>47,155</point2>
-</walk_boundary_def>
+<map file_name="./maps/map6nf_cave.elm" name="portland cave">
+	<walk_boundary_def location="Bridge over water">
+		<sound>Stone 2Foot</sound>
+		<point1>36,150</point1>
+		<point2>47,155</point2>
+	</walk_boundary_def>
 </map>
-<map id="145" name="Morcraven">
+<map file_name="./maps/map7.elm" name="Morcraven">
 	<boundary_def>
 		<background>Swamp Day</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -953,72 +921,62 @@
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
- 	<walk_boundary_def location="dock">	
-	  <sound>Wood 2Foot</sound>
-	  <point1>149,342</point1>
-	  <point2>153,362</point2>
- 	</walk_boundary_def>
- 	
+	<walk_boundary_def location="dock">
+		<sound>Wood 2Foot</sound>
+		<point1>149,342</point1>
+		<point2>153,362</point2>
+	</walk_boundary_def>
 </map>
-<map id="146" name="Morcraven insides">
-<walk_boundary_def location="Small log over chasm">
-<sound>Wood 2Foot</sound>
-<point1>73,230</point1>
-<point2>89,231</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Medium log over chasm">
-<sound>Wood 2Foot</sound>
-<point1>140,187</point1>
-<point2>141,202</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Mound on water">
-<sound>Dirt 2Foot</sound>
-<point1>218,178</point1>
-<point2>223,184</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Other mound on water">
-<sound>Dirt 2Foot</sound>
-<point1>198,177</point1>
-<point2>202,184</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Log over water">
-<sound>Wood 2Foot</sound>
-<point1>211,185</point1>
-<point2>214,190</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Platform over water">
-<sound>Stone 2Foot</sound>
-<point1>336,31</point1>
-<point2>364,52</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Platforms in lava room">
-<sound>Stone 2Foot</sound>
-<point1>342,216</point1>
-<point2>371,251</point2>
-</walk_boundary_def>
+<map file_name="./maps/map7_insides.elm" name="Morcraven insides">
+	<walk_boundary_def location="Small log over chasm">
+		<sound>Wood 2Foot</sound>
+		<point1>73,230</point1>
+		<point2>89,231</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Medium log over chasm">
+		<sound>Wood 2Foot</sound>
+		<point1>140,187</point1>
+		<point2>141,202</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Mound on water">
+		<sound>Dirt 2Foot</sound>
+		<point1>218,178</point1>
+		<point2>223,184</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Other mound on water">
+		<sound>Dirt 2Foot</sound>
+		<point1>198,177</point1>
+		<point2>202,184</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Log over water">
+		<sound>Wood 2Foot</sound>
+		<point1>211,185</point1>
+		<point2>214,190</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Platform over water">
+		<sound>Stone 2Foot</sound>
+		<point1>336,31</point1>
+		<point2>364,52</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Platforms in lava room">
+		<sound>Stone 2Foot</sound>
+		<point1>342,216</point1>
+		<point2>371,251</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="147" name="Morcraven cave">
-<walk_boundary_def location="Small boat south">
-<sound>Wood 2Foot</sound>
-<point1>63,32</point1>
-<point2>65,36</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Small boat north">
-<sound>Wood 2Foot</sound>
-<point1>71,87</point1>
-<point2>75,89</point2>
-</walk_boundary_def>
+<map file_name="./maps/map7_cave.elm" name="Morcraven cave">
+	<walk_boundary_def location="Small boat south">
+		<sound>Wood 2Foot</sound>
+		<point1>63,32</point1>
+		<point2>65,36</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Small boat north">
+		<sound>Wood 2Foot</sound>
+		<point1>71,87</point1>
+		<point2>75,89</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="151" name="Grubani">
+<map file_name="./maps/map9f.elm" name="Grubani">
 	<boundary_def>
 		<background>Swamp Day</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -1029,13 +987,13 @@
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
- 	<walk_boundary_def location="left side of summoning area">	
-	  <sound>Dirt 2Foot</sound>
-	  <point1>37,80</point1>
-	  <point2>41,109</point2>
- 	</walk_boundary_def>	
+	<walk_boundary_def location="left side of summoning area">
+		<sound>Dirt 2Foot</sound>
+		<point1>37,80</point1>
+		<point2>41,109</point2>
+	</walk_boundary_def>
 </map>
-<map id="148" name="Naralik">
+<map file_name="./maps/map8.elm" name="Naralik">
 	<boundary_def>
 		<background>Meadow01</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -1051,32 +1009,28 @@
 		<point1>148,173</point1>
 		<point2>159,178</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Walkway outside sm. house">
 		<sound>Stone 2Foot</sound>
 		<point1>152,83</point1>
 		<point2>168,95</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Booksellers ledge">
 		<sound>Stone 2Foot</sound>
 		<point1>117,61</point1>
 		<point2>121,70</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Stairs to Bookseller">
 		<sound>Stone 2Foot</sound>
 		<point1>122,63</point1>
 		<point2>127,63</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Dirt covering boat">
 		<sound>Wood 2Foot</sound>
 		<point1>51,85</point1>
 		<point2>73,97</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-<map id="150" name="Naralik Catacombs">
+<map file_name="./maps/map8_catacombs.elm" name="Naralik Catacombs">
 	<boundary_def>
 		<background>Atmosphere Spooky01</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
@@ -1087,44 +1041,42 @@
 		<point1>95,161</point1>
 		<point2>108,174</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Bridge across lava">
 		<sound>Stone 2Foot</sound>
 		<point1>72,137</point1>
 		<point2>90,167</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Stone entrance foyer">
 		<sound>Stone 2Foot</sound>
 		<point1>170,170</point1>
 		<point2>180,179</point2>
-	</walk_boundary_def>	
-</map>	
-<map id="5" name="Crystal Cavern">
+	</walk_boundary_def>
+</map>
+<map file_name="./maps/cave1.elm" name="Crystal Cavern">
 	<boundary_def>
-	<background>Cave Water</background>
-	  <point1>64,150</point1>
-	  <point2>44,181</point2>
-	  <point3>143,181</point3>
-	  <point4>125,150</point4>
+		<background>Cave Water</background>
+		<point1>64,150</point1>
+		<point2>44,181</point2>
+		<point3>143,181</point3>
+		<point4>125,150</point4>
 	</boundary_def>
-	<boundary_def>	
-	<background>Cave Water</background>
-	  <point1>98,105</point1>
-	  <point2>124,121</point2>
+	<boundary_def>
+		<background>Cave Water</background>
+		<point1>98,105</point1>
+		<point2>124,121</point2>
 	</boundary_def>
-	<boundary_def>	
-	<background>Cave Water</background>
-	  <point1>0,0</point1>
-	  <point2>38,40</point2>
+	<boundary_def>
+		<background>Cave Water</background>
+		<point1>0,0</point1>
+		<point2>38,40</point2>
 	</boundary_def>
 	<walk_boundary_def location="Bridge over water">
 		<sound>Stone 2Foot</sound>
 		<point1>121,162</point1>
 		<point2>129,171</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-<map id="157" name="Underworld">
+<map file_name="./maps/mapunderworld1.elm" name="Underworld">
 	<boundary_def>
 		<background>Atmosphere Underworld</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
@@ -1135,60 +1087,49 @@
 		<point1>84,156</point1>
 		<point2>89,160</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Bridge over lava (east)">
 		<sound>Stone 2Foot</sound>
 		<point1>108,157</point1>
 		<point2>113,161</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Bridge over lava (south)">
 		<sound>Stone 2Foot</sound>
 		<point1>96,144</point1>
 		<point2>101,149</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Boardwalk over lava">
 		<sound>Wood 2Foot</sound>
 		<point1>102,115</point1>
 		<point2>113,121</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Dirtwalk over lava">
 		<sound>Dirt 2Foot</sound>
 		<point1>66,108</point1>
 		<point2>71,113</point2>
 	</walk_boundary_def>
 </map>
-
-
-<map id="133" name="WS Diamond Cave">
+<map file_name="./maps/map2_cave.elm" name="WS Diamond Cave">
 	<boundary_def>
 		<crowd>Mining Crowd</crowd>
 		<is_default>1</is_default>
 	</boundary_def>
 </map>
-
-<map id="2" name="c2 docks seridia">
+<map file_name="./maps/c2_docks_seridia.elm" name="c2 docks seridia">
 	<walk_boundary_def location="wooden dock around ship">
 		<sound>Wood 2Foot</sound>
 		<point1>48,77</point1>
 		<point2>71,82</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="wooden dock around ship 2">
 		<sound>Wood 2Foot</sound>
 		<point1>71,71</point1>
 		<point2>76,82</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Rock at entrance to dock">
 		<sound>Stone 2Foot</sound>
 		<point1>18,59</point1>
 		<point2>24,67</point2>
 	</walk_boundary_def>
-
-
 	<walk_boundary_def location="Rock 1 in path">
 		<sound>Stone 2Foot</sound>
 		<point1>29,74</point1>
@@ -1196,7 +1137,6 @@
 		<point3>32,78</point3>
 		<point4>31,74</point4>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Rock 2 in path">
 		<sound>Stone 2Foot</sound>
 		<point1>24,69</point1>
@@ -1204,37 +1144,21 @@
 		<point3>27,72</point3>
 		<point4>27,70</point4>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Rock 3 in path">
 		<sound>Stone 2Foot</sound>
 		<point1>23,54</point1>
 		<point2>26,57</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Rock 4 in path">
 		<sound>Stone 2Foot</sound>
 		<point1>28,53</point1>
 		<point2>31,55</point2>
 	</walk_boundary_def>
 </map>
-
-<map id="156" name="portals room">
+<map file_name="./maps/mapportalroom.elm" name="portals room">
 	<walk_boundary_def location="Walkway over water">
 		<sound>Stone 2Foot</sound>
 		<point1>43,30</point1>
 		<point2>58,54</point2>
 	</walk_boundary_def>
 </map>
-
-<!-- Example of sounds existing for the entire map, without coords:
-	<boundary_def>
-		<background>Forest03</background>
-		<time_of_day_flags>0x007e</time_of_day_flags>
-		<is_default>1</is_default>
-	</boundary_def>
-	<boundary_def>
-		<background>Wind1</background>
-		<time_of_day_flags>0x0f81</time_of_day_flags>
-		<is_default>1</is_default>
-	</boundary_def>
--->

--- a/dev-data-files/sound/mapsfx_c2.xml
+++ b/dev-data-files/sound/mapsfx_c2.xml
@@ -1,14 +1,14 @@
-<map id="8" name="Idaloran">
+<map file_name="./maps/cont2map1.elm" name="Idaloran">
 	<boundary_def location="Forest lower left quadrant">
 		<background>Forest03</background>
-		<time_of_day_flags>0x007e</time_of_day_flags>	
-		<is_default>1</is_default>		
+		<time_of_day_flags>0x007e</time_of_day_flags>
+		<is_default>1</is_default>
 	</boundary_def>
 	<boundary_def location="Forest lower left quadrant">
 		<background>Forest Night02</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>	
+	</boundary_def>
 	<boundary_def location="Beach">
 		<background>Waves01</background>
 		<point1>10,414</point1>
@@ -28,21 +28,21 @@
 		<point1>155,547</point1>
 		<point2>253,702</point2>
 		<point3>332,702</point3>
-		<point4>269,547</point4>	
+		<point4>269,547</point4>
 	</boundary_def>
 	<boundary_def location="spooky forest">
 		<background>Atmosphere Spooky01</background>
 		<point1>420,473</point1>
 		<point2>420,613</point2>
 		<point3>568,589</point3>
-		<point4>570,473</point4>			
+		<point4>570,473</point4>
 	</boundary_def>
 	<boundary_def location="desert">
 		<background>Desert01</background>
 		<point1>503,268</point1>
 		<point2>594,570</point2>
 		<point3>746,570</point3>
-		<point4>746,291</point4>		
+		<point4>746,291</point4>
 	</boundary_def>
 	<walk_boundary_def location="Small island">
 		<sound>Dirt 2Foot</sound>
@@ -78,7 +78,7 @@
 		<sound>Stone 2Foot</sound>
 		<point1>498,73</point1>
 		<point2>523,74</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 	<walk_boundary_def location="bridge">
 		<sound>Stone 2Foot</sound>
 		<point1>430,283</point1>
@@ -93,45 +93,40 @@
 		<sound>Stone 2Foot</sound>
 		<point1>466,183</point1>
 		<point2>481,190</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-
-<map id="9" name="Idaloran Caves">
-<walk_boundary_def location="Wooden platform">
-<sound>Wood 2Foot</sound>
-<point1>157,49</point1>
-<point2>166,58</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map1_caves.elm" name="Idaloran Caves">
+	<walk_boundary_def location="Wooden platform">
+		<sound>Wood 2Foot</sound>
+		<point1>157,49</point1>
+		<point2>166,58</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="11" name="Idaloran Mines">
-<walk_boundary_def location="Wooden platform">
-<sound>Wood 2Foot</sound>
-<point1>278,116</point1>
-<point2>283,121</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden bridge over archway">
-<sound>Wood 2Foot</sound>
-<point1>198,102</point1>
-<point2>227,106</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden platform between tracks">
-<sound>Wood 2Foot</sound>
-<point1>105,182</point1>
-<point2>116,194</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map1_mine.elm" name="Idaloran Mines">
+	<walk_boundary_def location="Wooden platform">
+		<sound>Wood 2Foot</sound>
+		<point1>278,116</point1>
+		<point2>283,121</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden bridge over archway">
+		<sound>Wood 2Foot</sound>
+		<point1>198,102</point1>
+		<point2>227,106</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden platform between tracks">
+		<sound>Wood 2Foot</sound>
+		<point1>105,182</point1>
+		<point2>116,194</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="0" name="Anitora">
+<map file_name="./maps/anitora.elm" name="Anitora">
 	<boundary_def>
 		<background>Waves01</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 </map>
-<map id="42" name="Bethel">
+<map file_name="./maps/cont2map2.elm" name="Bethel">
 	<boundary_def>
 		<background>Desert01</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
@@ -162,41 +157,36 @@
 		<point1>54,166</point1>
 		<point2>49,181</point2>
 		<point3>63,181</point3>
-		<point4>63,166</point4>		
-	</walk_boundary_def>	
+		<point4>63,166</point4>
+	</walk_boundary_def>
 </map>
-
-<map id="43" name="Bethel caves">
-<walk_boundary_def location="Rocks around hole in ground">
-<sound>Stone 2Foot</sound>
-<point1>153,105</point1>
-<point2>162,109</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map2_cave.elm" name="Bethel caves">
+	<walk_boundary_def location="Rocks around hole in ground">
+		<sound>Stone 2Foot</sound>
+		<point1>153,105</point1>
+		<point2>162,109</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="44" name="Bethel insides">
-<walk_boundary_def location="Stone walk with stairs">
-<sound>Stone 2Foot</sound>
-<point1>25,53</point1>
-<point2>34,83</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone walk up from dirt">
-<sound>Stone 2Foot</sound>
-<point1>128,63</point1>
-<point2>159,95</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map2_insides.elm" name="Bethel insides">
+	<walk_boundary_def location="Stone walk with stairs">
+		<sound>Stone 2Foot</sound>
+		<point1>25,53</point1>
+		<point2>34,83</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone walk up from dirt">
+		<sound>Stone 2Foot</sound>
+		<point1>128,63</point1>
+		<point2>159,95</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="45" name="Bethel misc">
-<walk_boundary_def location="Wooden platform">
-<sound>Wood 2Foot</sound>
-<point1>175,53</point1>
-<point2>175,57</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map2_misc.elm" name="Bethel misc">
+	<walk_boundary_def location="Wooden platform">
+		<sound>Wood 2Foot</sound>
+		<point1>175,53</point1>
+		<point2>175,57</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="64" name="Sedicolis">
+<map file_name="./maps/cont2map3.elm" name="Sedicolis">
 	<boundary_def>
 		<background>Meadow01</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -212,53 +202,47 @@
 		<point1>53,131</point1>
 		<point2>58,146</point2>
 		<point3>73,145</point3>
-		<point4>75,126</point4>		
+		<point4>75,126</point4>
 	</walk_boundary_def>
 	<walk_boundary_def location="stone in water">
 		<sound>Stone 2Foot</sound>
 		<point1>92,126</point1>
 		<point2>99,129</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-
-<map id="65" name="Sedicolis insides">
-<walk_boundary_def location="Wooden stairs">
-<sound>Wood 2Foot</sound>
-<point1>47,27</point1>
-<point2>57,28</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden foyer">
-<sound>Wood 2Foot</sound>
-<point1>37,30</point1>
-<point2>62,34</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt mound">
-<sound>Dirt 2Foot</sound>
-<point1>66,27</point1>
-<point2>69,28</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt mound">
-<sound>Dirt 2Foot</sound>
-<point1>81,32</point1>
-<point2>82,35</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Part of large dirt mound">
-<sound>Dirt 2Foot</sound>
-<point1>72,36</point1>
-<point2>77,41</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Large dirt mound">
-<sound>Dirt 2Foot</sound>
-<point1>72,42</point1>
-<point2>82,52</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map3_insides.elm" name="Sedicolis insides">
+	<walk_boundary_def location="Wooden stairs">
+		<sound>Wood 2Foot</sound>
+		<point1>47,27</point1>
+		<point2>57,28</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden foyer">
+		<sound>Wood 2Foot</sound>
+		<point1>37,30</point1>
+		<point2>62,34</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt mound">
+		<sound>Dirt 2Foot</sound>
+		<point1>66,27</point1>
+		<point2>69,28</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt mound">
+		<sound>Dirt 2Foot</sound>
+		<point1>81,32</point1>
+		<point2>82,35</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Part of large dirt mound">
+		<sound>Dirt 2Foot</sound>
+		<point1>72,36</point1>
+		<point2>77,41</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Large dirt mound">
+		<sound>Dirt 2Foot</sound>
+		<point1>72,42</point1>
+		<point2>82,52</point2>
+	</walk_boundary_def>
 </map>
-<map id="66" name="Melinis">
+<map file_name="./maps/cont2map4.elm" name="Melinis">
 	<boundary_def>
 		<background>Desert01</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
@@ -278,136 +262,115 @@
 		<sound>Stone 2Foot</sound>
 		<point1>216,156</point1>
 		<point2>245,174</point2>
-	</walk_boundary_def>		
+	</walk_boundary_def>
 	<walk_boundary_def location="dirt near ladder in the corner">
 		<sound>Stone 2Foot</sound>
 		<point1>15,324</point1>
 		<point2>28,344</point2>
 		<point3>43,329</point3>
-		<point4>30,318</point4>		
-	</walk_boundary_def>	
+		<point4>30,318</point4>
+	</walk_boundary_def>
 </map>
-
-<map id="68" name="Melinis insides">
-<walk_boundary_def location="wooden bridge in sewers">
-<sound>Wood 2Foot</sound>
-<point1>206,156</point1>
-<point2>216,165</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map4_insides.elm" name="Melinis insides">
+	<walk_boundary_def location="wooden bridge in sewers">
+		<sound>Wood 2Foot</sound>
+		<point1>206,156</point1>
+		<point2>216,165</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="67" name="Melinis caves">
-<walk_boundary_def location="elevated area in a lava cave">
-<sound>Stone 2Foot</sound>
-<point1>34,34</point1>
-<point2>54,56</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="elevated area in a lava cave">
-<sound>Stone 2Foot</sound>
-<point1>78,24</point1>
-<point2>131,65</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="tiles above lava near sulfur">
-<sound>Dirt 2Foot</sound>
-<point1>194,29</point1>
-<point2>231,35</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="bridge in a lava cave">
-<sound>Stone 2Foot</sound>
-<point1>192,77</point1>
-<point2>196,96</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="tiles above water">
-<sound>Dirt 2Foot</sound>
-<point1>192,162</point1>
-<point2>209,179</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="elevated area in a lava cave">
-<sound>Stone 2Foot</sound>
-<point1>67,147</point1>
-<point2>81,166</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="bridges above lava">
-<sound>Stone 2Foot</sound>
-<point1>75,222</point1>
-<point2>153,257</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="bridge above lava">
-<sound>Stone 2Foot</sound>
-<point1>84,259</point1>
-<point2>100,280</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="">
-<sound>Stone 2Foot</sound>
-<point1>34,34</point1>
-<point2>54,56</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="wooden bench">
-<sound>Wood 2Foot</sound>
-<point1>154,302</point1>
-<point2>154,310</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="wooden bench">
-<sound>Wood 2Foot</sound>
-<point1>157,313</point1>
-<point2>165,313</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location=" tiles above water">
-<sound>Dirt 2Foot</sound>
-<point1>168,402</point1>
-<point2>197,443</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="magic arena">
-<sound>Stone 2Foot</sound>
-<point1>407,647</point1>
-<point2>432,666</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="wooden bridge in sewers">
-<sound>Wood 2Foot</sound>
-<point1>576,674</point1>
-<point2>581,675</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="wooden bridge in sewers">
-<sound>Wood 2Foot</sound>
-<point1>649,646</point1>
-<point2>649,655</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="wooden bridge in sewers">
-<sound>Wood 2Foot</sound>
-<point1>613,726</point1>
-<point2>614,737</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="wooden bridge in sewers">
-<sound>Wood 2Foot</sound>
-<point1>669,726</point1>
-<point2>670,737</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="wooden bridge in sewers">
-<sound>Wood 2Foot</sound>
-<point1>696,716</point1>
-<point2>707,718</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map4_caves.elm" name="Melinis caves">
+	<walk_boundary_def location="elevated area in a lava cave">
+		<sound>Stone 2Foot</sound>
+		<point1>34,34</point1>
+		<point2>54,56</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="elevated area in a lava cave">
+		<sound>Stone 2Foot</sound>
+		<point1>78,24</point1>
+		<point2>131,65</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="tiles above lava near sulfur">
+		<sound>Dirt 2Foot</sound>
+		<point1>194,29</point1>
+		<point2>231,35</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="bridge in a lava cave">
+		<sound>Stone 2Foot</sound>
+		<point1>192,77</point1>
+		<point2>196,96</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="tiles above water">
+		<sound>Dirt 2Foot</sound>
+		<point1>192,162</point1>
+		<point2>209,179</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="elevated area in a lava cave">
+		<sound>Stone 2Foot</sound>
+		<point1>67,147</point1>
+		<point2>81,166</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="bridges above lava">
+		<sound>Stone 2Foot</sound>
+		<point1>75,222</point1>
+		<point2>153,257</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="bridge above lava">
+		<sound>Stone 2Foot</sound>
+		<point1>84,259</point1>
+		<point2>100,280</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="">
+		<sound>Stone 2Foot</sound>
+		<point1>34,34</point1>
+		<point2>54,56</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wooden bench">
+		<sound>Wood 2Foot</sound>
+		<point1>154,302</point1>
+		<point2>154,310</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wooden bench">
+		<sound>Wood 2Foot</sound>
+		<point1>157,313</point1>
+		<point2>165,313</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location=" tiles above water">
+		<sound>Dirt 2Foot</sound>
+		<point1>168,402</point1>
+		<point2>197,443</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="magic arena">
+		<sound>Stone 2Foot</sound>
+		<point1>407,647</point1>
+		<point2>432,666</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wooden bridge in sewers">
+		<sound>Wood 2Foot</sound>
+		<point1>576,674</point1>
+		<point2>581,675</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wooden bridge in sewers">
+		<sound>Wood 2Foot</sound>
+		<point1>649,646</point1>
+		<point2>649,655</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wooden bridge in sewers">
+		<sound>Wood 2Foot</sound>
+		<point1>613,726</point1>
+		<point2>614,737</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wooden bridge in sewers">
+		<sound>Wood 2Foot</sound>
+		<point1>669,726</point1>
+		<point2>670,737</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wooden bridge in sewers">
+		<sound>Wood 2Foot</sound>
+		<point1>696,716</point1>
+		<point2>707,718</point2>
+	</walk_boundary_def>
 </map>
-
-
-<map id="69" name="Palon vertas">
+<map file_name="./maps/cont2map5.elm" name="Palon vertas">
 	<boundary_def>
 		<background>Meadow01</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
@@ -418,107 +381,89 @@
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
-<walk_boundary_def location="White Stone Bridge">
-<sound>Stone 2Foot</sound>
-<point1>165,120</point1>
-<point2>167,131</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Draw Bridge">
-<sound>Wood 2Foot</sound>
-<point1>252,233</point1>
-<point2>256,244</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Thelinor Bridge">
-<sound>Stone 2Foot</sound>
-<point1>349,288</point1>
-<point2>363,310</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="River Bridge">
-<sound>Stone 2Foot</sound>
-<point1>66,113</point1>
-<point2>70,126</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wood crossover">
-<sound>Wood 2Foot</sound>
-<point1>37,161</point1>
-<point2>38,169</point2>
-</walk_boundary_def>	
+	<walk_boundary_def location="White Stone Bridge">
+		<sound>Stone 2Foot</sound>
+		<point1>165,120</point1>
+		<point2>167,131</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Draw Bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>252,233</point1>
+		<point2>256,244</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Thelinor Bridge">
+		<sound>Stone 2Foot</sound>
+		<point1>349,288</point1>
+		<point2>363,310</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="River Bridge">
+		<sound>Stone 2Foot</sound>
+		<point1>66,113</point1>
+		<point2>70,126</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wood crossover">
+		<sound>Wood 2Foot</sound>
+		<point1>37,161</point1>
+		<point2>38,169</point2>
+	</walk_boundary_def>
 </map>
-
-
-<map id="70" name="Palon vertas Underground">
-<walk_boundary_def location="Lava bridge">
-<sound>Stone 2Foot</sound>
-<point1>41,294</point1>
-<point2>59,307</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden bridge">
-<sound>Wood 2Foot</sound>
-<point1>83,116</point1>
-<point2>87,140</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden bridge">
-<sound>Wood 2Foot</sound>
-<point1>88,135</point1>
-<point2>109,160</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden bridge">
-<sound>Wood 2Foot</sound>
-<point1>110,155</point1>
-<point2>186,183</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden bridge">
-<sound>Wood 2Foot</sound>
-<point1>179,146</point1>
-<point2>182,154</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden bridge">
-<sound>Wood 2Foot</sound>
-<point1>217,122</point1>
-<point2>302,175</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden bridge">
-<sound>Wood 2Foot</sound>
-<point1>194,158</point1>
-<point2>236,185</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map5_underground.elm" name="Palon vertas Underground">
+	<walk_boundary_def location="Lava bridge">
+		<sound>Stone 2Foot</sound>
+		<point1>41,294</point1>
+		<point2>59,307</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>83,116</point1>
+		<point2>87,140</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>88,135</point1>
+		<point2>109,160</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>110,155</point1>
+		<point2>186,183</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>179,146</point1>
+		<point2>182,154</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>217,122</point1>
+		<point2>302,175</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>194,158</point1>
+		<point2>236,185</point2>
+	</walk_boundary_def>
 </map>
-
-
-<map id="73" name="Palon vertas cave">
-<walk_boundary_def location="Wooden platform">
-<sound>Wood 2Foot</sound>
-<point1>52,96</point1>
-<point2>70,109</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map5_caves.elm" name="Palon vertas cave">
+	<walk_boundary_def location="Wooden platform">
+		<sound>Wood 2Foot</sound>
+		<point1>52,96</point1>
+		<point2>70,109</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="72" name="Palon vertas insides">
-<walk_boundary_def location="Fountain walk">
-<sound>Stone 2Foot</sound>
-<point1>294,343</point1>
-<point2>306,356</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Bath">
-<sound>Water 2Foot</sound>
-<point1>453,113</point1>
-<point2>457,117</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map5_insides.elm" name="Palon vertas insides">
+	<walk_boundary_def location="Fountain walk">
+		<sound>Stone 2Foot</sound>
+		<point1>294,343</point1>
+		<point2>306,356</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Bath">
+		<sound>Water 2Foot</sound>
+		<point1>453,113</point1>
+		<point2>457,117</point2>
+	</walk_boundary_def>
 </map>
-
-
-<map id="74" name="Thelinor">
+<map file_name="./maps/cont2map6.elm" name="Thelinor">
 	<boundary_def>
 		<background>Swamp Day</background>
 		<point1>0,0</point1>
@@ -542,7 +487,8 @@
 		<background>Swamp Night</background>
 		<point1>0,191</point1>
 		<point2>185,261</point2>
-		<time_of_day_flags>0x0f81</time_of_day_flags>>
+		<time_of_day_flags>0x0f81</time_of_day_flags>
+		&gt;
 	</boundary_def>
 	<boundary_def>
 		<background>Meadow01</background>
@@ -555,13 +501,13 @@
 		<point1>0,262</point1>
 		<point2>186,383</point2>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
-	</boundary_def>		
+	</boundary_def>
 	<boundary_def>
 		<background>Meadow01</background>
 		<point1>266,0</point1>
 		<point2>266,190</point2>
 		<point3>382,225</point3>
-		<point4>382,0</point4>		
+		<point4>382,0</point4>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 	</boundary_def>
 	<boundary_def>
@@ -569,9 +515,9 @@
 		<point1>266,0</point1>
 		<point2>266,190</point2>
 		<point3>382,225</point3>
-		<point4>382,0</point4>		
+		<point4>382,0</point4>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
-	</boundary_def>		
+	</boundary_def>
 	<boundary_def>
 		<background>Forest Night02</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
@@ -596,146 +542,127 @@
 		<sound>Dirt 2Foot</sound>
 		<point1>142,106</point1>
 		<point2>230,178</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-
-<map id="76" name="Thelinor Insides">
-<walk_boundary_def location="dirt tile in tent">
-<sound>Dirt 2Foot</sound>
-<point1>31,31</point1>
-<point2>39,39</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="dirt tile in tent">
-<sound>Dirt 2Foot</sound>
-<point1>73,32</point1>
-<point2>81,39</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="dirt tile in tent">
-<sound>Dirt 2Foot</sound>
-<point1>116,32</point1>
-<point2>123,39</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map6_insides.elm" name="Thelinor Insides">
+	<walk_boundary_def location="dirt tile in tent">
+		<sound>Dirt 2Foot</sound>
+		<point1>31,31</point1>
+		<point2>39,39</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="dirt tile in tent">
+		<sound>Dirt 2Foot</sound>
+		<point1>73,32</point1>
+		<point2>81,39</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="dirt tile in tent">
+		<sound>Dirt 2Foot</sound>
+		<point1>116,32</point1>
+		<point2>123,39</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="75" name="Thelinor caves">
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>20,42</point1>
-<point2>23,47</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>30,42</point1>
-<point2>32,44</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>31,33</point1>
-<point2>35,35</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>26,134</point1>
-<point2>29,137</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>16,101</point1>
-<point2>17,105</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>20,108</point1>
-<point2>23,111</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>27,114</point1>
-<point2>29,117</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>36,92</point1>
-<point2>39,95</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>30,42</point1>
-<point2>32,44</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>36,108</point1>
-<point2>39,111</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="elevated area">
-<sound>Stone 2Foot</sound>
-<point1>41,162</point1>
-<point2>58,182</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>96,76</point1>
-<point2>98,78</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="minor dirt above rock tile">
-<sound>Dirt 2Foot</sound>
-<point1>102,81</point1>
-<point2>107,83</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map6_caves.elm" name="Thelinor caves">
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>20,42</point1>
+		<point2>23,47</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>30,42</point1>
+		<point2>32,44</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>31,33</point1>
+		<point2>35,35</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>26,134</point1>
+		<point2>29,137</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>16,101</point1>
+		<point2>17,105</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>20,108</point1>
+		<point2>23,111</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>27,114</point1>
+		<point2>29,117</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>36,92</point1>
+		<point2>39,95</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>30,42</point1>
+		<point2>32,44</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>36,108</point1>
+		<point2>39,111</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="elevated area">
+		<sound>Stone 2Foot</sound>
+		<point1>41,162</point1>
+		<point2>58,182</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>96,76</point1>
+		<point2>98,78</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="minor dirt above rock tile">
+		<sound>Dirt 2Foot</sound>
+		<point1>102,81</point1>
+		<point2>107,83</point2>
+	</walk_boundary_def>
 </map>
-
-
-
-<map id="77" name="Irsis">
+<map file_name="./maps/cont2map7.elm" name="Irsis">
 	<boundary_def>
 		<background>Meadow01</background>
 		<point1>255,55</point1>
-		<point2>383,383</point2>		
+		<point2>383,383</point2>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 	<boundary_def>
 		<background>Forest Night01</background>
 		<point1>255,55</point1>
-		<point2>383,383</point2>		
+		<point2>383,383</point2>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>	
+	</boundary_def>
 	<boundary_def location="South Beach">
 		<background>Waves01</background>
 		<point1>111,0</point1>
 		<point2>117,69</point2>
 		<point3>366,54</point3>
-		<point4>376,0</point4>	
+		<point4>376,0</point4>
 	</boundary_def>
 	<boundary_def location="northwest Beach">
 		<background>Waves01</background>
 		<point1>66,228</point1>
 		<point2>178,313</point2>
 		<point3>213,309</point3>
-		<point4>111,228</point4>		
+		<point4>111,228</point4>
 	</boundary_def>
 	<boundary_def location="northwest island and beach">
 		<background>Waves01</background>
 		<point1>23,297</point1>
 		<point2>29,377</point2>
 		<point3>226,382</point3>
-		<point4>203,307</point4>		
+		<point4>203,307</point4>
 	</boundary_def>
 	<walk_boundary_def location="ships">
 		<sound>Stone 2Foot</sound>
@@ -756,7 +683,7 @@
 		<sound>Stone 2Foot</sound>
 		<point1>158,138</point1>
 		<point2>165,146</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 	<walk_boundary_def location="bridge">
 		<sound>Stone 2Foot</sound>
 		<point1>155,218</point1>
@@ -811,59 +738,52 @@
 		<sound>Leaves 2Foot</sound>
 		<point1>255,144</point1>
 		<point2>269,162</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-
-<map id="78" name="Irsis insides">
-<walk_boundary_def location="Dirt area">
-<sound>Dirt 2Foot</sound>
-<point1>84,42</point1>
-<point2>89,53</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt area">
-<sound>Dirt 2Foot</sound>
-<point1>90,48</point1>
-<point2>95,53</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt area">
-<sound>Dirt 2Foot</sound>
-<point1>96,42</point1>
-<point2>101,53</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone platform over water">
-<sound>Stone 2Foot</sound>
-<point1>30,114</point1>
-<point2>35,119</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone walk over lava">
-<sound>Stone 2Foot</sound>
-<point1>90,114</point1>
-<point2>95,125</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone stairs">
-<sound>Stone 2Foot</sound>
-<point1>253,354</point1>
-<point2>255,359</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map7_insides.elm" name="Irsis insides">
+	<walk_boundary_def location="Dirt area">
+		<sound>Dirt 2Foot</sound>
+		<point1>84,42</point1>
+		<point2>89,53</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt area">
+		<sound>Dirt 2Foot</sound>
+		<point1>90,48</point1>
+		<point2>95,53</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt area">
+		<sound>Dirt 2Foot</sound>
+		<point1>96,42</point1>
+		<point2>101,53</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone platform over water">
+		<sound>Stone 2Foot</sound>
+		<point1>30,114</point1>
+		<point2>35,119</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone walk over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>90,114</point1>
+		<point2>95,125</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone stairs">
+		<sound>Stone 2Foot</sound>
+		<point1>253,354</point1>
+		<point2>255,359</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="79" name="Emerald Valley">
+<map file_name="./maps/cont2map8.elm" name="Emerald Valley">
 	<boundary_def>
 		<background>Forest01</background>
 		<point1>0,0</point1>
-		<point2>127,383</point2>		
+		<point2>127,383</point2>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 	<boundary_def>
 		<background>Forest Night01</background>
 		<point1>0,0</point1>
-		<point2>127,383</point2>		
+		<point2>127,383</point2>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
@@ -872,15 +792,15 @@
 		<point1>128,231</point1>
 		<point2>128,383</point2>
 		<point3>383,383</point3>
-		<point4>383,178</point4>			
+		<point4>383,178</point4>
 		<time_of_day_flags>0x007e</time_of_day_flags>
-	</boundary_def>	
+	</boundary_def>
 	<boundary_def>
 		<background>Forest Night01</background>
 		<point1>128,231</point1>
 		<point2>128,383</point2>
 		<point3>383,383</point3>
-		<point4>383,178</point4>			
+		<point4>383,178</point4>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 	</boundary_def>
 	<boundary_def>
@@ -888,116 +808,100 @@
 		<point1>128,0</point1>
 		<point2>128,230</point2>
 		<point3>383,177</point3>
-		<point4>383,0</point4>			
-	</boundary_def>		
+		<point4>383,0</point4>
+	</boundary_def>
 	<walk_boundary_def location="Wooden Stage">
 		<sound>Wood 2Foot</sound>
 		<point1>305,259</point1>
 		<point2>318,270</point2>
 	</walk_boundary_def>
-
-<walk_boundary_def location="Wood Steps 1">
-<sound>Wood 2Foot</sound>
-<point1>310,295</point1>
-<point2>312,287</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Walkable Rock on grass">
-<sound>Stone 2Foot</sound>
-<point1>170,250</point1>
-<point2>174,154</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone Bridge">
-<sound>Stone 2Foot</sound>
-<point1>119,259</point1>
-<point2>132,261</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Steps up to teleport arrival place">
-<sound>Stone 2Foot</sound>
-<point1>218,345</point1>
-<point2>224,353</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Teleport arrival place">
-<sound>Stone 2Foot</sound>
-<point1>215,353</point1>
-<point2>228,365</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Walkable rock on grass 2">
-<sound>Stone 2Foot</sound>
-<point1>258,329</point1>
-<point2>261,333</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone Birdge 2">
-<sound>Stone 2Foot</sound>
-<point1>231,319</point1>
-<point2>233,340</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Large Walkable Rock Face">
-<sound>Stone 2Foot</sound>
-<point1>147,325</point1>
-<point2>167,341</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Small Wooden Bridge">
-<sound>Wood 2Foot</sound>
-<point1>336,68</point1>
-<point2>348,69</point2>
-</walk_boundary_def>
+	<walk_boundary_def location="Wood Steps 1">
+		<sound>Wood 2Foot</sound>
+		<point1>310,295</point1>
+		<point2>312,287</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Walkable Rock on grass">
+		<sound>Stone 2Foot</sound>
+		<point1>170,250</point1>
+		<point2>174,154</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone Bridge">
+		<sound>Stone 2Foot</sound>
+		<point1>119,259</point1>
+		<point2>132,261</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Steps up to teleport arrival place">
+		<sound>Stone 2Foot</sound>
+		<point1>218,345</point1>
+		<point2>224,353</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Teleport arrival place">
+		<sound>Stone 2Foot</sound>
+		<point1>215,353</point1>
+		<point2>228,365</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Walkable rock on grass 2">
+		<sound>Stone 2Foot</sound>
+		<point1>258,329</point1>
+		<point2>261,333</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone Birdge 2">
+		<sound>Stone 2Foot</sound>
+		<point1>231,319</point1>
+		<point2>233,340</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Large Walkable Rock Face">
+		<sound>Stone 2Foot</sound>
+		<point1>147,325</point1>
+		<point2>167,341</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Small Wooden Bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>336,68</point1>
+		<point2>348,69</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="81" name="Emerald valley insides">
-<walk_boundary_def location="Stone staircase">
-<sound>Stone 2Foot</sound>
-<point1>150,79</point1>
-<point2>155,81</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone staircase">
-<sound>Stone 2Foot</sound>
-<point1>24,131</point1>
-<point2>28,135</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map8_insides.elm" name="Emerald valley insides">
+	<walk_boundary_def location="Stone staircase">
+		<sound>Stone 2Foot</sound>
+		<point1>150,79</point1>
+		<point2>155,81</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone staircase">
+		<sound>Stone 2Foot</sound>
+		<point1>24,131</point1>
+		<point2>28,135</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="80" name="Emerald valley cave">
-<walk_boundary_def location="Train tracks over empty space">
-<sound>Wood 2Foot</sound>
-<point1>142,32</point1>
-<point2>143,66</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone walkway over dirt">
-<sound>Stone 2Foot</sound>
-<point1>119,113</point1>
-<point2>153,128</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt mound on stone">
-<sound>Dirt 2Foot</sound>
-<point1>79,163</point1>
-<point2>90,172</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone walk over lava">
-<sound>Stone 2Foot</sound>
-<point1>20,132</point1>
-<point2>30,154</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map8_cave.elm" name="Emerald valley cave">
+	<walk_boundary_def location="Train tracks over empty space">
+		<sound>Wood 2Foot</sound>
+		<point1>142,32</point1>
+		<point2>143,66</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone walkway over dirt">
+		<sound>Stone 2Foot</sound>
+		<point1>119,113</point1>
+		<point2>153,128</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt mound on stone">
+		<sound>Dirt 2Foot</sound>
+		<point1>79,163</point1>
+		<point2>90,172</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone walk over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>20,132</point1>
+		<point2>30,154</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="82" name="Kusamura">
+<map file_name="./maps/cont2map9.elm" name="Kusamura">
 	<boundary_def>
 		<background>Forest04</background>
 		<point1>304,0</point1>
 		<point2>0,383</point2>
 		<point3>383,383</point3>
-		<point4>383,0</point4>			
+		<point4>383,0</point4>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
@@ -1006,16 +910,16 @@
 		<point1>304,0</point1>
 		<point2>0,383</point2>
 		<point3>383,383</point3>
-		<point4>383,0</point4>			
+		<point4>383,0</point4>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>		
+	</boundary_def>
 	<boundary_def>
 		<background>Swamp Day</background>
 		<point1>0,0</point1>
 		<point2>0,342</point2>
 		<point3>94,287</point3>
-		<point4>297,0</point4>			
+		<point4>297,0</point4>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 	</boundary_def>
 	<boundary_def>
@@ -1023,7 +927,7 @@
 		<point1>0,0</point1>
 		<point2>0,342</point2>
 		<point3>94,287</point3>
-		<point4>297,0</point4>				
+		<point4>297,0</point4>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 	</boundary_def>
 	<boundary_def>
@@ -1031,9 +935,8 @@
 		<point1>233,203</point1>
 		<point2>233,220</point2>
 		<point3>261,226</point3>
-		<point4>263,208</point4>			
-	</boundary_def>	
-
+		<point4>263,208</point4>
+	</boundary_def>
 	<walk_boundary_def location="bridge">
 		<sound>Stone 2Foot</sound>
 		<point1>149,157</point1>
@@ -1049,14 +952,14 @@
 		<point1>254,208</point1>
 		<point2>244,222</point2>
 		<point3>255,227</point3>
-		<point4>265,214</point4>			
+		<point4>265,214</point4>
 	</walk_boundary_def>
 	<walk_boundary_def location="area with tents in the corner">
 		<sound>Grass 2Foot</sound>
 		<point1>0,336</point1>
 		<point2>12,336</point2>
 		<point3>383,31</point3>
-		<point4>383,0</point4>			
+		<point4>383,0</point4>
 	</walk_boundary_def>
 	<walk_boundary_def location="platform">
 		<sound>Stone 2Foot</sound>
@@ -1067,50 +970,44 @@
 		<sound>Stone 2Foot</sound>
 		<point1>173,336</point1>
 		<point2>183,345</point2>
-	</walk_boundary_def>	
-	
+	</walk_boundary_def>
 </map>
-
-<map id="83" name="Kusamura insides">
-<walk_boundary_def location="Wooden bridge">
-<sound>Wood 2Foot</sound>
-<point1>35,71</point1>
-<point2>47,72</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map9_insides.elm" name="Kusamura insides">
+	<walk_boundary_def location="Wooden bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>35,71</point1>
+		<point2>47,72</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="84" name="Kusamura temple">
-<walk_boundary_def location="Stone stairs">
-<sound>Stone 2Foot</sound>
-<point1>95,39</point1>
-<point2>109,51</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt walkway">
-<sound>Dirt 2Foot</sound>
-<point1>28,126</point1>
-<point2>33,138</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Branch walkway on lava">
-<sound>Wood 2Foot</sound>
-<point1>169,61</point1>
-<point2>178,68</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map9_temple.elm" name="Kusamura temple">
+	<walk_boundary_def location="Stone stairs">
+		<sound>Stone 2Foot</sound>
+		<point1>95,39</point1>
+		<point2>109,51</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt walkway">
+		<sound>Dirt 2Foot</sound>
+		<point1>28,126</point1>
+		<point2>33,138</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Branch walkway on lava">
+		<sound>Wood 2Foot</sound>
+		<point1>169,61</point1>
+		<point2>178,68</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="12" name="Zirakinbar">
+<map file_name="./maps/cont2map10.elm" name="Zirakinbar">
 	<boundary_def>
 		<background>Meadow01</background>
 		<point1>0,0</point1>
-		<point2>135,225</point2>		
+		<point2>135,225</point2>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 	<boundary_def>
 		<background>Forest Night01</background>
 		<point1>0,0</point1>
-		<point2>135,225</point2>		
+		<point2>135,225</point2>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
@@ -1119,7 +1016,7 @@
 		<point1>0,136</point1>
 		<point2>136,383</point2>
 		<point3>300,383</point3>
-		<point4>206,0</point4>		
+		<point4>206,0</point4>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 	</boundary_def>
 	<boundary_def>
@@ -1127,7 +1024,7 @@
 		<point1>0,136</point1>
 		<point2>136,383</point2>
 		<point3>300,383</point3>
-		<point4>206,0</point4>		
+		<point4>206,0</point4>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 	</boundary_def>
 	<boundary_def>
@@ -1135,7 +1032,7 @@
 		<point1>218,0</point1>
 		<point2>323,383</point2>
 		<point3>383,291</point3>
-		<point4>383,0</point4>		
+		<point4>383,0</point4>
 	</boundary_def>
 	<walk_boundary_def location="Docks">
 		<sound>Wood 2Foot</sound>
@@ -1181,228 +1078,195 @@
 		<sound>Stone 2Foot</sound>
 		<point1>16,226</point1>
 		<point2>21,266</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-
-<map id="14" name="Zirakinbar insides">
-<walk_boundary_def location="Wooden platform">
-<sound>Wood 2Foot</sound>
-<point1>48,24</point1>
-<point2>71,38</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden plankway over water">
-<sound>Wood 2Foot</sound>
-<point1>177,241</point1>
-<point2>186,269</point2>
-<point3>201,269</point3>
-<point4>208,241</point4>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden bridge over water">
-<sound>Wood 2Foot</sound>
-<point1>180,270</point1>
-<point2>185,273</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Tracks over water">
-<sound>Wood 2Foot</sound>
-<point1>180,284</point1>
-<point2>185,286</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden bridge over water">
-<sound>Wood 2Foot</sound>
-<point1>60,246</point1>
-<point2>65,248</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden bridge over water">
-<sound>Wood 2Foot</sound>
-<point1>140,288</point1>
-<point2>142,293</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Tracks over water">
-<sound>Wood 2Foot</sound>
-<point1>83,325</point1>
-<point2>101,341</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Tracks over water">
-<sound>Wood 2Foot</sound>
-<point1>102,330</point1>
-<point2>145,342</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wood over water">
-<sound>Wood 2Foot</sound>
-<point1>147,330</point1>
-<point2>233,354</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wood over water">
-<sound>Wood 2Foot</sound>
-<point1>280,324</point1>
-<point2>286,340</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map10_insides.elm" name="Zirakinbar insides">
+	<walk_boundary_def location="Wooden platform">
+		<sound>Wood 2Foot</sound>
+		<point1>48,24</point1>
+		<point2>71,38</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden plankway over water">
+		<sound>Wood 2Foot</sound>
+		<point1>177,241</point1>
+		<point2>186,269</point2>
+		<point3>201,269</point3>
+		<point4>208,241</point4>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden bridge over water">
+		<sound>Wood 2Foot</sound>
+		<point1>180,270</point1>
+		<point2>185,273</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Tracks over water">
+		<sound>Wood 2Foot</sound>
+		<point1>180,284</point1>
+		<point2>185,286</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden bridge over water">
+		<sound>Wood 2Foot</sound>
+		<point1>60,246</point1>
+		<point2>65,248</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden bridge over water">
+		<sound>Wood 2Foot</sound>
+		<point1>140,288</point1>
+		<point2>142,293</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Tracks over water">
+		<sound>Wood 2Foot</sound>
+		<point1>83,325</point1>
+		<point2>101,341</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Tracks over water">
+		<sound>Wood 2Foot</sound>
+		<point1>102,330</point1>
+		<point2>145,342</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wood over water">
+		<sound>Wood 2Foot</sound>
+		<point1>147,330</point1>
+		<point2>233,354</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wood over water">
+		<sound>Wood 2Foot</sound>
+		<point1>280,324</point1>
+		<point2>286,340</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="13" name="Zirakinbar caves">
-<walk_boundary_def location="Stone path across water">
-<sound>Stone 2Foot</sound>
-<point1>157,30</point1>
-<point2>170,35</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone walk over lava">
-<sound>Stone 2Foot</sound>
-<point1>92,34</point1>
-<point2>98,55</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden platform">
-<sound>Wood 2Foot</sound>
-<point1>86,56</point1>
-<point2>95,60</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone walk over lava">
-<sound>Stone 2Foot</sound>
-<point1>45,54</point1>
-<point2>85,60</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone walkway over lava">
-<sound>Stone 2Foot</sound>
-<point1>34,49</point1>
-<point2>44,77</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden planks to small boats">
-<sound>Wood 2Foot</sound>
-<point1>34,93</point1>
-<point2>41,103</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone platform over lava">
-<sound>Stone 2Foot</sound>
-<point1>119,168</point1>
-<point2>136,179</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone platform over lava">
-<sound>Stone 2Foot</sound>
-<point1>169,134</point1>
-<point2>171,134</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Brick platform on dirt">
-<sound>Stone 2Foot</sound>
-<point1>136,147</point1>
-<point2>147,158</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map10_caves.elm" name="Zirakinbar caves">
+	<walk_boundary_def location="Stone path across water">
+		<sound>Stone 2Foot</sound>
+		<point1>157,30</point1>
+		<point2>170,35</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone walk over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>92,34</point1>
+		<point2>98,55</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden platform">
+		<sound>Wood 2Foot</sound>
+		<point1>86,56</point1>
+		<point2>95,60</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone walk over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>45,54</point1>
+		<point2>85,60</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone walkway over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>34,49</point1>
+		<point2>44,77</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden planks to small boats">
+		<sound>Wood 2Foot</sound>
+		<point1>34,93</point1>
+		<point2>41,103</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone platform over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>119,168</point1>
+		<point2>136,179</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone platform over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>169,134</point1>
+		<point2>171,134</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Brick platform on dirt">
+		<sound>Stone 2Foot</sound>
+		<point1>136,147</point1>
+		<point2>147,158</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="15" name="Willowvine">
+<map file_name="./maps/cont2map11.elm" name="Willowvine">
 	<boundary_def>
-		<background>Forest04</background>		
+		<background>Forest04</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 	<boundary_def>
-		<background>Forest Night01</background>		
+		<background>Forest Night01</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
-<walk_boundary_def location="Rock outcrop on dirt">
-<sound>Stone 2Foot</sound>
-<point1>48,72</point1>
-<point2>48,92</point2>
-<point3>86,66</point3>
-<point4>57,59</point4>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dock and winged boat">
-<sound>Wood 2Foot</sound>
-<point1>35,330</point1>
-<point2>56,349</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Gravel on dirt">
-<sound>Stone 2Foot</sound>
-<point1>155,353</point1>
-<point2>168,366</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden plank">
-<sound>Wood 2Foot</sound>
-<point1>371,100</point1>
-<point2>376,105</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden walkway in trees">
-<sound>Wood 2Foot</sound>
-<point1>324,121</point1>
-<point2>341,130</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden walkway in trees">
-<sound>Wood 2Foot</sound>
-<point1>309,131</point1>
-<point2>371,210</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden walkway in trees">
-<sound>Wood 2Foot</sound>
-<point1>125,98</point1>
-<point2>201,186</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden walkway in trees">
-<sound>Wood 2Foot</sound>
-<point1>255,316</point1>
-<point2>323,371</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden walkway in trees">
-<sound>Wood 2Foot</sound>
-<point1>324,324</point1>
-<point2>332,326</point2>
-</walk_boundary_def>
+	<walk_boundary_def location="Rock outcrop on dirt">
+		<sound>Stone 2Foot</sound>
+		<point1>48,72</point1>
+		<point2>48,92</point2>
+		<point3>86,66</point3>
+		<point4>57,59</point4>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dock and winged boat">
+		<sound>Wood 2Foot</sound>
+		<point1>35,330</point1>
+		<point2>56,349</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Gravel on dirt">
+		<sound>Stone 2Foot</sound>
+		<point1>155,353</point1>
+		<point2>168,366</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden plank">
+		<sound>Wood 2Foot</sound>
+		<point1>371,100</point1>
+		<point2>376,105</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden walkway in trees">
+		<sound>Wood 2Foot</sound>
+		<point1>324,121</point1>
+		<point2>341,130</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden walkway in trees">
+		<sound>Wood 2Foot</sound>
+		<point1>309,131</point1>
+		<point2>371,210</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden walkway in trees">
+		<sound>Wood 2Foot</sound>
+		<point1>125,98</point1>
+		<point2>201,186</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden walkway in trees">
+		<sound>Wood 2Foot</sound>
+		<point1>255,316</point1>
+		<point2>323,371</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden walkway in trees">
+		<sound>Wood 2Foot</sound>
+		<point1>324,324</point1>
+		<point2>332,326</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="17" name="Willowvine insides">
-<walk_boundary_def location="bridge in evil temple">
-<sound>Wood 2Foot</sound>
-<point1>65,312</point1>
-<point2>90,313</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="stone bridge in skill academy">
-<sound>Stone 2Foot</sound>
-<point1>213,268</point1>
-<point2>230,270</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map11_insides.elm" name="Willowvine insides">
+	<walk_boundary_def location="bridge in evil temple">
+		<sound>Wood 2Foot</sound>
+		<point1>65,312</point1>
+		<point2>90,313</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stone bridge in skill academy">
+		<sound>Stone 2Foot</sound>
+		<point1>213,268</point1>
+		<point2>230,270</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="16" name="Willowvine cave">
-<walk_boundary_def location="Stone Bridge">
-<sound>Stone 2Foot</sound>
-<point1>39,123</point1>
-<point2>86,127</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map11_cave1.elm" name="Willowvine cave">
+	<walk_boundary_def location="Stone Bridge">
+		<sound>Stone 2Foot</sound>
+		<point1>39,123</point1>
+		<point2>86,127</point2>
+	</walk_boundary_def>
 </map>
-
-
-<map id="18" name="Aeth Aelfan">
+<map file_name="./maps/cont2map12.elm" name="Aeth Aelfan">
 	<boundary_def>
-		<background>Forest04</background>		
+		<background>Forest04</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 	<boundary_def>
-		<background>Forest Night01</background>		
+		<background>Forest Night01</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
@@ -1411,300 +1275,249 @@
 		<point1>353,127</point1>
 		<point2>357,147</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="On the boat to Glacmor">
 		<sound>Wood 2Foot</sound>
 		<point1>346,122</point1>
 		<point2>352,144</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="On the boat to Zirakinbar and half the ramp up">
 		<sound>Wood 2Foot</sound>
 		<point1>317,130</point1>
 		<point2>322,144</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Small wall edging the docks 1">
 		<sound>Stone 2Foot</sound>
 		<point1>335,126</point1>
 		<point2>336,149</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Small wall edging the docks 2">
 		<sound>Stone 2Foot</sound>
 		<point1>337,148</point1>
 		<point2>359,149</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Small wall edging the docks 3">
 		<sound>Stone 2Foot</sound>
 		<point1>358,127</point1>
 		<point2>359,149</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Small wall edging the docks 4">
 		<sound>Stone 2Foot</sound>
 		<point1>353,125</point1>
 		<point2>359,126</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Small wall edging the docks 5">
 		<sound>Stone 2Foot</sound>
 		<point1>353,113</point1>
 		<point2>354,124</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Dirt at the south-east corner of the dock-wall">
 		<sound>Dirt 2Foot</sound>
 		<point1>355,108</point1>
 		<point2>356,113</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Bridge connecting east and west of map">
 		<sound>Stone 2Foot</sound>
 		<point1>270,212</point1>
 		<point2>281,214</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="South-west fortress, near the parasol">
 		<sound>Grass 2Foot</sound>
 		<point1>78,168</point1>
 		<point2>82,171</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="South-west fortress, on the parasol 1 #overlap A">
 		<sound>Stone 2Foot</sound>
 		<point1>72,159</point1>
 		<point2>76,166</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="South-west fortress, on the parasol 2 #overlap A">
 		<sound>Stone 2Foot</sound>
 		<point1>70,161</point1>
 		<point2>78,174</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="North Bridge out of the fortress, plus some of the path north of it">
 		<sound>Stone 2Foot</sound>
 		<point1>78,248</point1>
 		<point2>80,265</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Shikane Bridge within the fortress">
 		<sound>Stone 2Foot</sound>
 		<point1>152,168</point1>
 		<point2>154,185</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Patch of dirt over water, south-west of map 1">
 		<sound>Dirt 2Foot</sound>
 		<point1>57,26</point1>
 		<point2>65,29</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Patch of dirt over water, south-west of map 2">
 		<sound>Dirt 2Foot</sound>
 		<point1>71,22</point1>
 		<point2>77,27</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Some docking on the south-east beach">
 		<sound>Wood 2Foot</sound>
 		<point1>335,40</point1>
 		<point2>340,51</point2>
 	</walk_boundary_def>
 </map>
-
-
-
-<map id="20" name="Aeth Aelfan insides">
-<walk_boundary_def location="Stone platform">
-<sound>Stone 2Foot</sound>
-<point1>340,339</point1>
-<point2>357,356</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden Bridge">
-<sound>Wood 2Foot</sound>
-<point1>291,351</point1>
-<point2>299,352</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone Bridge">
-<sound>Stone 2Foot</sound>
-<point1>275,350</point1>
-<point2>290,353</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map12_insides.elm" name="Aeth Aelfan insides">
+	<walk_boundary_def location="Stone platform">
+		<sound>Stone 2Foot</sound>
+		<point1>340,339</point1>
+		<point2>357,356</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden Bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>291,351</point1>
+		<point2>299,352</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone Bridge">
+		<sound>Stone 2Foot</sound>
+		<point1>275,350</point1>
+		<point2>290,353</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="21" name="Aeth Aelfan cave1">
-<walk_boundary_def location="Wooden boat">
-<sound>Wood 2Foot</sound>
-<point1>249,31</point1>
-<point2>250,35</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt mound">
-<sound>Dirt 2Foot</sound>
-<point1>236,28</point1>
-<point2>241,34</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt mound">
-<sound>Dirt 2Foot</sound>
-<point1>238,45</point1>
-<point2>242,51</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt on rocky ground">
-<sound>Dirt 2Foot</sound>
-<point1>164,43</point1>
-<point2>194,47</point2>
-<point3>183,30</point3>
-<point4>175,31</point4>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt on stone walkway">
-<sound>Dirt 2Foot</sound>
-<point1>101,107</point1>
-<point2>105,114</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt on stone walkway">
-<sound>Dirt 2Foot</sound>
-<point1>111,113</point1>
-<point2>113,114</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt on stone walkway">
-<sound>Dirt 2Foot</sound>
-<point1>106,116</point1>
-<point2>109,118</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone staircase">
-<sound>Stone 2Foot</sound>
-<point1>26,48</point1>
-<point2>27,55</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone on dirt walk">
-<sound>Stone 2Foot</sound>
-<point1>101,102</point1>
-<point2>112,118</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone on dirt walk">
-<sound>Stone 2Foot</sound>
-<point1>79,27</point1>
-<point2>93,35</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone on dirt walk">
-<sound>Stone 2Foot</sound>
-<point1>22,117</point1>
-<point2>35,145</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone bridge over water">
-<sound>Stone 2Foot</sound>
-<point1>144,235</point1>
-<point2>165,238</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden walk over water">
-<sound>Wood 2Foot</sound>
-<point1>84,284</point1>
-<point2>99,299</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden walkway">
-<sound>Wood 2Foot</sound>
-<point1>72,288</point1>
-<point2>83,296</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Grass on dirt">
-<sound>Grass 2Foot</sound>
-<point1>260,147</point1>
-<point2>273,153</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt bridge over water">
-<sound>Dirt 2Foot</sound>
-<point1>162,111</point1>
-<point2>163,123</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map12_cave1.elm" name="Aeth Aelfan cave1">
+	<walk_boundary_def location="Wooden boat">
+		<sound>Wood 2Foot</sound>
+		<point1>249,31</point1>
+		<point2>250,35</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt mound">
+		<sound>Dirt 2Foot</sound>
+		<point1>236,28</point1>
+		<point2>241,34</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt mound">
+		<sound>Dirt 2Foot</sound>
+		<point1>238,45</point1>
+		<point2>242,51</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt on rocky ground">
+		<sound>Dirt 2Foot</sound>
+		<point1>164,43</point1>
+		<point2>194,47</point2>
+		<point3>183,30</point3>
+		<point4>175,31</point4>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt on stone walkway">
+		<sound>Dirt 2Foot</sound>
+		<point1>101,107</point1>
+		<point2>105,114</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt on stone walkway">
+		<sound>Dirt 2Foot</sound>
+		<point1>111,113</point1>
+		<point2>113,114</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt on stone walkway">
+		<sound>Dirt 2Foot</sound>
+		<point1>106,116</point1>
+		<point2>109,118</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone staircase">
+		<sound>Stone 2Foot</sound>
+		<point1>26,48</point1>
+		<point2>27,55</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone on dirt walk">
+		<sound>Stone 2Foot</sound>
+		<point1>101,102</point1>
+		<point2>112,118</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone on dirt walk">
+		<sound>Stone 2Foot</sound>
+		<point1>79,27</point1>
+		<point2>93,35</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone on dirt walk">
+		<sound>Stone 2Foot</sound>
+		<point1>22,117</point1>
+		<point2>35,145</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone bridge over water">
+		<sound>Stone 2Foot</sound>
+		<point1>144,235</point1>
+		<point2>165,238</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden walk over water">
+		<sound>Wood 2Foot</sound>
+		<point1>84,284</point1>
+		<point2>99,299</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden walkway">
+		<sound>Wood 2Foot</sound>
+		<point1>72,288</point1>
+		<point2>83,296</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Grass on dirt">
+		<sound>Grass 2Foot</sound>
+		<point1>260,147</point1>
+		<point2>273,153</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt bridge over water">
+		<sound>Dirt 2Foot</sound>
+		<point1>162,111</point1>
+		<point2>163,123</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="22" name="Aeth Aelfan cave2">
-<walk_boundary_def location="Dirt splotch on rock">
-<sound>Dirt 2Foot</sound>
-<point1>28,34</point1>
-<point2>31,37</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt splotch on rock">
-<sound>Dirt 2Foot</sound>
-<point1>26,44</point1>
-<point2>30,46</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt splotch on rock">
-<sound>Dirt 2Foot</sound>
-<point1>60,68</point1>
-<point2>64,70</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map12_cave2.elm" name="Aeth Aelfan cave2">
+	<walk_boundary_def location="Dirt splotch on rock">
+		<sound>Dirt 2Foot</sound>
+		<point1>28,34</point1>
+		<point2>31,37</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt splotch on rock">
+		<sound>Dirt 2Foot</sound>
+		<point1>26,44</point1>
+		<point2>30,46</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt splotch on rock">
+		<sound>Dirt 2Foot</sound>
+		<point1>60,68</point1>
+		<point2>64,70</point2>
+	</walk_boundary_def>
 </map>
-
-
-<map id="19" name="Aeth Aelfan fortress">
-<walk_boundary_def location="Wooden platform on rock tiles">
-<sound>Wood 2Foot</sound>
-<point1>156,97</point1>
-<point2>178,116</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone staircase">
-<sound>Stone 2Foot</sound>
-<point1>95,115</point1>
-<point2>102,118</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden platform on rock tiles">
-<sound>Wood 2Foot</sound>
-<point1>24,101</point1>
-<point2>34,106</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wooden platform on rock tiles">
-<sound>Wood 2Foot</sound>
-<point1>19,136</point1>
-<point2>34,142</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt splotch on various surfaces">
-<sound>Dirt 2Foot</sound>
-<point1>79,40</point1>
-<point2>81,44</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone walk over lava">
-<sound>Stone 2Foot</sound>
-<point1>114,61</point1>
-<point2>143,89</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map12_fortress.elm" name="Aeth Aelfan fortress">
+	<walk_boundary_def location="Wooden platform on rock tiles">
+		<sound>Wood 2Foot</sound>
+		<point1>156,97</point1>
+		<point2>178,116</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone staircase">
+		<sound>Stone 2Foot</sound>
+		<point1>95,115</point1>
+		<point2>102,118</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden platform on rock tiles">
+		<sound>Wood 2Foot</sound>
+		<point1>24,101</point1>
+		<point2>34,106</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wooden platform on rock tiles">
+		<sound>Wood 2Foot</sound>
+		<point1>19,136</point1>
+		<point2>34,142</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt splotch on various surfaces">
+		<sound>Dirt 2Foot</sound>
+		<point1>79,40</point1>
+		<point2>81,44</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone walk over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>114,61</point1>
+		<point2>143,89</point2>
+	</walk_boundary_def>
 </map>
-
-
-
-<map id="24" name="Egratia">
+<map file_name="./maps/cont2map13.elm" name="Egratia">
 	<boundary_def>
 		<background>Meadow01</background>
 		<point1>0,134</point1>
 		<point2>0,191</point2>
 		<point3>147,191</point3>
-		<point4>104,128</point4>		
+		<point4>104,128</point4>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
@@ -1713,7 +1526,7 @@
 		<point1>0,134</point1>
 		<point2>0,191</point2>
 		<point3>147,191</point3>
-		<point4>104,128</point4>		
+		<point4>104,128</point4>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
@@ -1722,54 +1535,49 @@
 		<point1>0,0</point1>
 		<point2>0,133</point2>
 		<point3>191,133</point3>
-		<point4>191,0</point4>		
+		<point4>191,0</point4>
 	</boundary_def>
 	<boundary_def>
 		<background>Desert01</background>
 		<point1>105,128</point1>
-		<point2>191,191</point2>	
+		<point2>191,191</point2>
 	</boundary_def>
 	<walk_boundary_def location="docks">
 		<sound>Wood 2Foot</sound>
 		<point1>52,37</point1>
 		<point2>65,59</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-
-
-<map id="25" name="Egratia temple">
-<walk_boundary_def location="Dirt on stone tiles">
-<sound>Dirt 2Foot</sound>
-<point1>46,59</point1>
-<point2>46,56</point2>
-<point3>49,62</point3>
-<point4>49,57</point4>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dirt path on stone tiles">
-<sound>Dirt 2Foot</sound>
-<point1>24,59</point1>
-<point2>45,60</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Rock tiles on dirt (on rock)">
-<sound>Stone 2Foot</sound>
-<point1>50,57</point1>
-<point2>67,62</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map13_temple.elm" name="Egratia temple">
+	<walk_boundary_def location="Dirt on stone tiles">
+		<sound>Dirt 2Foot</sound>
+		<point1>46,59</point1>
+		<point2>46,56</point2>
+		<point3>49,62</point3>
+		<point4>49,57</point4>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dirt path on stone tiles">
+		<sound>Dirt 2Foot</sound>
+		<point1>24,59</point1>
+		<point2>45,60</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Rock tiles on dirt (on rock)">
+		<sound>Stone 2Foot</sound>
+		<point1>50,57</point1>
+		<point2>67,62</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="26" name="Arius">
+<map file_name="./maps/cont2map14.elm" name="Arius">
 	<boundary_def>
-		<background>Meadow01</background>	
+		<background>Meadow01</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 	<boundary_def>
-		<background>Forest Night01</background>	
+		<background>Forest Night01</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>	
+	</boundary_def>
 	<walk_boundary_def location="grassy area in the north">
 		<sound>Grass 2Foot</sound>
 		<point1>6,331</point1>
@@ -1785,26 +1593,26 @@
 		<point1>6,181</point1>
 		<point2>23,219</point2>
 		<point3>41,215</point3>
-		<point4>22,180</point4>		
+		<point4>22,180</point4>
 	</walk_boundary_def>
 	<walk_boundary_def location="docks">
 		<sound>Wood 2Foot</sound>
 		<point1>23,215</point1>
-		<point2>40,236</point2>	
+		<point2>40,236</point2>
 	</walk_boundary_def>
 	<walk_boundary_def location="stone wall at docks">
 		<sound>Stone 2Foot</sound>
 		<point1>23,178</point1>
 		<point2>41,209</point2>
 		<point3>47,209</point3>
-		<point4>30,178</point4>		
+		<point4>30,178</point4>
 	</walk_boundary_def>
 	<walk_boundary_def location="flying ship and docks">
 		<sound>Wood 2Foot</sound>
 		<point1>218,297</point1>
 		<point2>216,342</point2>
 		<point3>226,342</point3>
-		<point4>223,297</point4>		
+		<point4>223,297</point4>
 	</walk_boundary_def>
 	<walk_boundary_def location="bridge">
 		<sound>Wood 2Foot</sound>
@@ -1875,37 +1683,36 @@
 		<sound>Stone 2Foot</sound>
 		<point1>32,24</point1>
 		<point2>46,39</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-<map id="27" name="Arius Insides">
-<walk_boundary_def location="steps with no floor tiles">
-<sound>Stone 2Foot</sound>
-<point1>270,66</point1>
-<point2>287,83</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="steps with no floor tiles 2">
-<sound>Stone 2Foot</sound>
-<point1>234,66</point1>
-<point2>245,83</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map14_insides.elm" name="Arius Insides">
+	<walk_boundary_def location="steps with no floor tiles">
+		<sound>Stone 2Foot</sound>
+		<point1>270,66</point1>
+		<point2>287,83</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="steps with no floor tiles 2">
+		<sound>Stone 2Foot</sound>
+		<point1>234,66</point1>
+		<point2>245,83</point2>
+	</walk_boundary_def>
 </map>
-<map id="28" name="North Redmoon">
+<map file_name="./maps/cont2map15.elm" name="North Redmoon">
 	<boundary_def>
 		<background>Forest04</background>
 		<point1>0,0</point1>
-		<point2>0,383</point2>	
+		<point2>0,383</point2>
 		<point3>157,365</point3>
-		<point4>369,0</point4>		
+		<point4>369,0</point4>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 	<boundary_def>
 		<background>Forest Night01</background>
 		<point1>0,0</point1>
-		<point2>0,383</point2>	
+		<point2>0,383</point2>
 		<point3>157,365</point3>
-		<point4>369,0</point4>		
+		<point4>369,0</point4>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
@@ -1938,9 +1745,9 @@
 		<sound>Dirt 2Foot</sound>
 		<point1>205,213</point1>
 		<point2>366,312</point2>
-	</walk_boundary_def>		
+	</walk_boundary_def>
 </map>
-<map id="31" name="North Redmoon mountains">
+<map file_name="./maps/cont2map15_mountain.elm" name="North Redmoon mountains">
 	<boundary_def>
 		<background>Wind01</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
@@ -1950,23 +1757,23 @@
 		<sound>Dirt 2Foot</sound>
 		<point1>0,0</point1>
 		<point2>383,383</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-<map id="32" name="South Redmoon">
+<map file_name="./maps/cont2map16.elm" name="South Redmoon">
 	<boundary_def>
 		<background>Forest03</background>
 		<point1>0,0</point1>
-		<point2>383,383</point2>		
+		<point2>383,383</point2>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 	<boundary_def>
 		<background>Forest Night02</background>
 		<point1>0,0</point1>
-		<point2>383,383</point2>		
+		<point2>383,383</point2>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>	
+	</boundary_def>
 	<walk_boundary_def location="docks">
 		<sound>Wood 2Foot</sound>
 		<point1>162,10</point1>
@@ -1992,37 +1799,34 @@
 		<point1>39,306</point1>
 		<point2>39,338</point2>
 		<point3>47,338</point3>
-		<point4>68,306</point4>			
-	</walk_boundary_def>	
+		<point4>68,306</point4>
+	</walk_boundary_def>
 </map>
-<map id="33" name="South Redmoon insides">
-<walk_boundary_def location="Stone Arc">
-<sound>Stone 2Foot</sound>
-<point1>304,270</point1>
-<point2>307,276</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wood Plank Left">
-<sound>Wood 2Foot</sound>
-<point1>102,136</point1>
-<point2>104,146</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Wood Plank Right">
-<sound>Wood 2Foot</sound>
-<point1>107,145</point1>
-<point2>113,146</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Dock Area">
-<sound>Wood 2Foot</sound>
-<point1>102,147</point1>
-<point2>110,188</point2>
-<point3>112,188</point3>
-<point4>107,147</point4>
-</walk_boundary_def>
+<map file_name="./maps/cont2map16_insides.elm" name="South Redmoon insides">
+	<walk_boundary_def location="Stone Arc">
+		<sound>Stone 2Foot</sound>
+		<point1>304,270</point1>
+		<point2>307,276</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wood Plank Left">
+		<sound>Wood 2Foot</sound>
+		<point1>102,136</point1>
+		<point2>104,146</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Wood Plank Right">
+		<sound>Wood 2Foot</sound>
+		<point1>107,145</point1>
+		<point2>113,146</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dock Area">
+		<sound>Wood 2Foot</sound>
+		<point1>102,147</point1>
+		<point2>110,188</point2>
+		<point3>112,188</point3>
+		<point4>107,147</point4>
+	</walk_boundary_def>
 </map>
-<map id="34" name="South Redmoon mountains">
+<map file_name="./maps/cont2map16_mountains.elm" name="South Redmoon mountains">
 	<boundary_def>
 		<background>Winter Wind</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
@@ -2032,19 +1836,19 @@
 		<sound>Snow 2Foot</sound>
 		<point1>0,0</point1>
 		<point2>191,191</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-<map id="35" name="Hurquin">
+<map file_name="./maps/cont2map17.elm" name="Hurquin">
 	<boundary_def>
-		<background>Forest02</background>	
+		<background>Forest02</background>
 		<time_of_day_flags>0x007e</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 	<boundary_def>
-		<background>Forest Night02</background>		
+		<background>Forest Night02</background>
 		<time_of_day_flags>0x0f81</time_of_day_flags>
 		<is_default>1</is_default>
-	</boundary_def>	
+	</boundary_def>
 	<walk_boundary_def location="docks">
 		<sound>Wood 2Foot</sound>
 		<point1>118,84</point1>
@@ -2079,329 +1883,272 @@
 		<sound>Dirt 2Foot</sound>
 		<point1>126,55</point1>
 		<point2>145,78</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-
-
-<map id="37" name="Hurquin insides">
-<walk_boundary_def location="Small Board 1">
-<sound>Wood 2Foot</sound>
-<point1>156,112</point1>
-<point2>160,114</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Lower Dock Area">
-<sound>Wood 2Foot</sound>
-<point1>154,81</point1>
-<point2>167,95</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Top Dock Area">
-<sound>Wood 2Foot</sound>
-<point1>168,98</point1>
-<point2>168,107</point2>
-<point3>169,111</point3>
-<point4>169,98</point4>
-</walk_boundary_def>
-
-<walk_boundary_def location="Left Dock Area">
-<sound>Wood 2Foot</sound>
-<point1>132,87</point1>
-<point2>137,92</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map17_insides.elm" name="Hurquin insides">
+	<walk_boundary_def location="Small Board 1">
+		<sound>Wood 2Foot</sound>
+		<point1>156,112</point1>
+		<point2>160,114</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Lower Dock Area">
+		<sound>Wood 2Foot</sound>
+		<point1>154,81</point1>
+		<point2>167,95</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Top Dock Area">
+		<sound>Wood 2Foot</sound>
+		<point1>168,98</point1>
+		<point2>168,107</point2>
+		<point3>169,111</point3>
+		<point4>169,98</point4>
+	</walk_boundary_def>
+	<walk_boundary_def location="Left Dock Area">
+		<sound>Wood 2Foot</sound>
+		<point1>132,87</point1>
+		<point2>137,92</point2>
+	</walk_boundary_def>
 </map>
-
-
-
-<map id="38" name="Trassian">
+<map file_name="./maps/cont2map18.elm" name="Trassian">
 	<boundary_def>
 		<background>Winter Wind</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
-<walk_boundary_def location="snow up north">
-<sound>Snow 2Foot</sound>
-<point1>30,180</point1>
-<point2>41,184</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="wooden dock down south">
-<sound>Wood 2Foot</sound>
-<point1>20,24</point1>
-<point2>25,34</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="rocky bridge in dra syn">
-<sound>Stone 2Foot</sound>
-<point1>33,119</point1>
-<point2>34,126</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="ice area near dragon statue in dra syn">
-<sound>Stone 2Foot</sound>
-<point1>114,108</point1>
-<point2>116,110</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="elevated area with water tile in dra syn">
-<sound>Snow 2Foot</sound>
-<point1>39,120</point1>
-<point2>41,125</point2>
-</walk_boundary_def>
+	<walk_boundary_def location="snow up north">
+		<sound>Snow 2Foot</sound>
+		<point1>30,180</point1>
+		<point2>41,184</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wooden dock down south">
+		<sound>Wood 2Foot</sound>
+		<point1>20,24</point1>
+		<point2>25,34</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="rocky bridge in dra syn">
+		<sound>Stone 2Foot</sound>
+		<point1>33,119</point1>
+		<point2>34,126</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="ice area near dragon statue in dra syn">
+		<sound>Stone 2Foot</sound>
+		<point1>114,108</point1>
+		<point2>116,110</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="elevated area with water tile in dra syn">
+		<sound>Snow 2Foot</sound>
+		<point1>39,120</point1>
+		<point2>41,125</point2>
+	</walk_boundary_def>
 </map>
-
-
-<map id="39" name="Trassian caves">
-<walk_boundary_def location="boat in cave">
-<sound>Wood 2Foot</sound>
-<point1>43,702</point1>
-<point2>47,703</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="rocky bridges in cave">
-<sound>Stone 2Foot</sound>
-<point1>124,702</point1>
-<point2>151,733</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="rocky bridge in cave">
-<sound>Stone 2Foot</sound>
-<point1>227,737</point1>
-<point2>252,739</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="snow before stepping into water in saret's cave">
-<sound>Snow 2Foot</sound>
-<point1>218,173</point1>
-<point2>224,174</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="snow before stepping into water in saret's cave">
-<sound>Snow 2Foot</sound>
-<point1>262,184</point1>
-<point2>266,185</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="snow before stepping into water in saret's cave">
-<sound>Snow 2Foot</sound>
-<point1>120,70</point1>
-<point2>126,71</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="bridge in saret's cave">
-<sound>Stone 2Foot</sound>
-<point1>215,62</point1>
-<point2>221,66</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="bridge in saret's cave">
-<sound>Stone 2Foot</sound>
-<point1>156,36</point1>
-<point2>160,42</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="bridge in saret's cave">
-<sound>Stone 2Foot</sound>
-<point1>128,53</point1>
-<point2>134,60</point2>
-<point3>137,57</point3>
-<point4>131,51</point4>
-</walk_boundary_def>
-
-<walk_boundary_def location="bridge in saret's cave">
-<sound>Stone 2Foot</sound>
-<point1>400,126</point1>
-<point2>412,157</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="wooden bridge in saret's cave">
-<sound>Wood 2Foot</sound>
-<point1>309,194</point1>
-<point2>340,226</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="elevated stone area in saret's cave">
-<sound>Stone 2Foot</sound>
-<point1>179,198</point1>
-<point2>208,223</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="sewer area">
-<sound>Stone 2Foot</sound>
-<point1>267,669</point1>
-<point2>302,692</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="stone ground in special cave">
-<sound>Stone 2Foot</sound>
-<point1>319,410</point1>
-<point2>335,449</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="stone ground in special cave">
-<sound>Stone 2Foot</sound>
-<point1>384,413</point1>
-<point2>399,449</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="stone ground in special cave">
-<sound>Stone 2Foot</sound>
-<point1>320,450</point1>
-<point2>398,454</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="elevated area with no ground tile in cave">
-<sound>Stone 2Foot</sound>
-<point1>439,480</point1>
-<point2>454,497</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="rocky bridge in meeting hall">
-<sound>Stone 2Foot</sound>
-<point1>126,337</point1>
-<point2>161,340</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="rocky bridge in deepstone cave">
-<sound>Stone 2Foot</sound>
-<point1>689,705</point1>
-<point2>702,709</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="rocky bridge in deepstone cave">
-<sound>Stone 2Foot</sound>
-<point1>707,689</point1>
-<point2>712,702</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="rocky bridge in deepstone cave">
-<sound>Stone 2Foot</sound>
-<point1>713,700</point1>
-<point2>732,705</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="rocky bridge in deepstone cave">
-<sound>Stone 2Foot</sound>
-<point1>711,712</point1>
-<point2>722,721</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="ground with no tile in knights hall">
-<sound>Stone 2Foot</sound>
-<point1>379,678</point1>
-<point2>383,682</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="ground with no tile in knights hall">
-<sound>Stone 2Foot</sound>
-<point1>378,667</point1>
-<point2>382,671</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="ground with no tile in knights hall">
-<sound>Stone 2Foot</sound>
-<point1>408,672</point1>
-<point2>413,676</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="ground with no tile in blacksmith school">
-<sound>Stone 2Foot</sound>
-<point1>500,144</point1>
-<point2>525,155</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="wooden bridge in cave">
-<sound>Wood 2Foot</sound>
-<point1>666,289</point1>
-<point2>689,291</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="ground with no tile in cave">
-<sound>Stone 2Foot</sound>
-<point1>655,240</point1>
-<point2>395,264</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="water maze">
-<sound>Stone 2Foot</sound>
-<point1>55,449</point1>
-<point2>275,550</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map18_caves.elm" name="Trassian caves">
+	<walk_boundary_def location="boat in cave">
+		<sound>Wood 2Foot</sound>
+		<point1>43,702</point1>
+		<point2>47,703</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="rocky bridges in cave">
+		<sound>Stone 2Foot</sound>
+		<point1>124,702</point1>
+		<point2>151,733</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="rocky bridge in cave">
+		<sound>Stone 2Foot</sound>
+		<point1>227,737</point1>
+		<point2>252,739</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="snow before stepping into water in saret's cave">
+		<sound>Snow 2Foot</sound>
+		<point1>218,173</point1>
+		<point2>224,174</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="snow before stepping into water in saret's cave">
+		<sound>Snow 2Foot</sound>
+		<point1>262,184</point1>
+		<point2>266,185</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="snow before stepping into water in saret's cave">
+		<sound>Snow 2Foot</sound>
+		<point1>120,70</point1>
+		<point2>126,71</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="bridge in saret's cave">
+		<sound>Stone 2Foot</sound>
+		<point1>215,62</point1>
+		<point2>221,66</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="bridge in saret's cave">
+		<sound>Stone 2Foot</sound>
+		<point1>156,36</point1>
+		<point2>160,42</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="bridge in saret's cave">
+		<sound>Stone 2Foot</sound>
+		<point1>128,53</point1>
+		<point2>134,60</point2>
+		<point3>137,57</point3>
+		<point4>131,51</point4>
+	</walk_boundary_def>
+	<walk_boundary_def location="bridge in saret's cave">
+		<sound>Stone 2Foot</sound>
+		<point1>400,126</point1>
+		<point2>412,157</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wooden bridge in saret's cave">
+		<sound>Wood 2Foot</sound>
+		<point1>309,194</point1>
+		<point2>340,226</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="elevated stone area in saret's cave">
+		<sound>Stone 2Foot</sound>
+		<point1>179,198</point1>
+		<point2>208,223</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="sewer area">
+		<sound>Stone 2Foot</sound>
+		<point1>267,669</point1>
+		<point2>302,692</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stone ground in special cave">
+		<sound>Stone 2Foot</sound>
+		<point1>319,410</point1>
+		<point2>335,449</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stone ground in special cave">
+		<sound>Stone 2Foot</sound>
+		<point1>384,413</point1>
+		<point2>399,449</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="stone ground in special cave">
+		<sound>Stone 2Foot</sound>
+		<point1>320,450</point1>
+		<point2>398,454</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="elevated area with no ground tile in cave">
+		<sound>Stone 2Foot</sound>
+		<point1>439,480</point1>
+		<point2>454,497</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="rocky bridge in meeting hall">
+		<sound>Stone 2Foot</sound>
+		<point1>126,337</point1>
+		<point2>161,340</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="rocky bridge in deepstone cave">
+		<sound>Stone 2Foot</sound>
+		<point1>689,705</point1>
+		<point2>702,709</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="rocky bridge in deepstone cave">
+		<sound>Stone 2Foot</sound>
+		<point1>707,689</point1>
+		<point2>712,702</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="rocky bridge in deepstone cave">
+		<sound>Stone 2Foot</sound>
+		<point1>713,700</point1>
+		<point2>732,705</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="rocky bridge in deepstone cave">
+		<sound>Stone 2Foot</sound>
+		<point1>711,712</point1>
+		<point2>722,721</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="ground with no tile in knights hall">
+		<sound>Stone 2Foot</sound>
+		<point1>379,678</point1>
+		<point2>383,682</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="ground with no tile in knights hall">
+		<sound>Stone 2Foot</sound>
+		<point1>378,667</point1>
+		<point2>382,671</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="ground with no tile in knights hall">
+		<sound>Stone 2Foot</sound>
+		<point1>408,672</point1>
+		<point2>413,676</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="ground with no tile in blacksmith school">
+		<sound>Stone 2Foot</sound>
+		<point1>500,144</point1>
+		<point2>525,155</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="wooden bridge in cave">
+		<sound>Wood 2Foot</sound>
+		<point1>666,289</point1>
+		<point2>689,291</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="ground with no tile in cave">
+		<sound>Stone 2Foot</sound>
+		<point1>655,240</point1>
+		<point2>395,264</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="water maze">
+		<sound>Stone 2Foot</sound>
+		<point1>55,449</point1>
+		<point2>275,550</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="55" name="Imbroglio lava maze">
-<walk_boundary_def location="entire map">
-<sound>Stone 2Foot</sound>
-<point1>0,0</point1>
-<point2>300,200</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map21_maze6.elm" name="Imbroglio lava maze">
+	<walk_boundary_def location="entire map">
+		<sound>Stone 2Foot</sound>
+		<point1>0,0</point1>
+		<point2>300,200</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="41" name="Hulda">
+<map file_name="./maps/cont2map19.elm" name="Hulda">
 	<boundary_def>
 		<background>Winter Wind</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
 </map>
-
-
-<map id="46" name="IOTF">
+<map file_name="/maps/cont2map20.elm" name="IOTF">
 	<boundary_def>
 		<background>Winter Wind</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
-	<walk_boundary_def location="IotF Wooden Bridge"> 
+	<walk_boundary_def location="IotF Wooden Bridge">
 		<sound>Snow 2Foot</sound>
 		<point1>0,0</point1>
 		<point2>191,191</point2>
 	</walk_boundary_def>
-	<walk_boundary_def location="IotF Wooden Bridge"> 
+	<walk_boundary_def location="IotF Wooden Bridge">
 		<sound>Wood 2Foot</sound>
 		<point1>82,147</point1>
 		<point2>102,148</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-
-
-<map id="47" name="IOTF insides">
-<walk_boundary_def location="Island">
-<sound>Dirt 2Foot</sound>
-<point1>175,85</point1>
-<point2>191,105</point2>
-</walk_boundary_def>
-
-
-<walk_boundary_def location="gen store">
-<sound>Wood 2Foot</sound>
-<point1>228,81</point1>
-<point2>255,100</point2>
-</walk_boundary_def>
-
-
-<walk_boundary_def location="secret spot">
-<sound>Stone 2Foot</sound>
-<point1>250,193</point1>
-<point2>277,219</point2>
-</walk_boundary_def>
-
-
-<walk_boundary_def location="Dryx temple bridge">
-<sound>Wood 2Foot</sound>
-<point1>51,337</point1>
-<point2>62,342</point2>
-</walk_boundary_def>
-
-
-<walk_boundary_def location="tracks over water">
-<sound>Wood 2Foot</sound>
-<point1>306,296</point1>
-<point2>310,315</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map20_insides.elm" name="IOTF insides">
+	<walk_boundary_def location="Island">
+		<sound>Dirt 2Foot</sound>
+		<point1>175,85</point1>
+		<point2>191,105</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="gen store">
+		<sound>Wood 2Foot</sound>
+		<point1>228,81</point1>
+		<point2>255,100</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="secret spot">
+		<sound>Stone 2Foot</sound>
+		<point1>250,193</point1>
+		<point2>277,219</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Dryx temple bridge">
+		<sound>Wood 2Foot</sound>
+		<point1>51,337</point1>
+		<point2>62,342</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="tracks over water">
+		<sound>Wood 2Foot</sound>
+		<point1>306,296</point1>
+		<point2>310,315</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="48" name="Imbroglio">
+<map file_name="./maps/cont2map21.elm" name="Imbroglio">
 	<boundary_def>
 		<background>Winter Wind</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
@@ -2431,15 +2178,14 @@
 		<sound>Wood 2Foot</sound>
 		<point1>276,103</point1>
 		<point2>290,108</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 	<walk_boundary_def location="south platform">
 		<sound>Wood 2Foot</sound>
 		<point1>274,100</point1>
 		<point2>279,102</point2>
 	</walk_boundary_def>
 </map>
-
-<map id="56" name="Irinveron">
+<map file_name="./maps/cont2map22.elm" name="Irinveron">
 	<boundary_def>
 		<background>Winter Wind</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
@@ -2459,10 +2205,9 @@
 		<sound>Wood 2Foot</sound>
 		<point1>401,274</point1>
 		<point2>472,439</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-
-<map id="59" name="Glacmor">
+<map file_name="./maps/cont2map23.elm" name="Glacmor">
 	<boundary_def>
 		<background>Winter Wind</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
@@ -2473,39 +2218,33 @@
 		<point1>194,232</point1>
 		<point2>199,240</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Ramp Up To Aeth Aeflan Boat">
 		<sound>Wood 2Foot</sound>
 		<point1>197,241</point1>
 		<point2>198,242</point2>
 	</walk_boundary_def>
-
 	<walk_boundary_def location="Boat To Aeth Aeflan">
 		<sound>Wood 2Foot</sound>
 		<point1>186,243</point1>
 		<point2>204,248</point2>
 	</walk_boundary_def>
-
-
 	<walk_boundary_def location="Small unused boat">
 		<sound>Wood 2Foot</sound>
 		<point1>258,236</point1>
 		<point2>266,237</point2>
 	</walk_boundary_def>
-	
 	<walk_boundary_def location="wrecked ship">
 		<sound>Dirt 2Foot</sound>
 		<point1>65,366</point1>
 		<point2>86,374</point2>
 	</walk_boundary_def>
-	
 	<walk_boundary_def location="lake lower right">
 		<sound>Stone 2Foot</sound>
 		<point1>312,36</point1>
 		<point2>348,72</point2>
-	</walk_boundary_def>	
+	</walk_boundary_def>
 </map>
-<map id="60" name="Glacmor insides">
+<map file_name="./maps/cont2map23_insides.elm" name="Glacmor insides">
 	<walk_boundary_def location="top floor restaurant">
 		<sound>Dirt 2Foot</sound>
 		<point1>137,66</point1>
@@ -2517,161 +2256,138 @@
 		<point2>283,137</point2>
 	</walk_boundary_def>
 </map>
-<map id="61" name="Iscalrith">
+<map file_name="./maps/cont2map24.elm" name="Iscalrith">
 	<boundary_def>
 		<background>Winter Wind</background>
 		<time_of_day_flags>0xffff</time_of_day_flags>
 		<is_default>1</is_default>
 	</boundary_def>
-<walk_boundary_def location="Boat 1">
-<sound>Wood 2Foot</sound>
-<point1>240,341</point1>
-<point2>246,355</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Docks and Other Boats">
-<sound>Wood 2Foot</sound>
-<point1>247,330</point1>
-<point2>285,358</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone Bridge 1">
-<sound>Stone 2Foot</sound>
-<point1>92,48</point1>
-<point2>99,50</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone Bridge 2">
-<sound>Stone 2Foot</sound>
-<point1>122,47</point1>
-<point2>130,49</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Small Boat">
-<sound>Wood 2Foot</sound>
-<point1>116,72</point1>
-<point2>118,78</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Large Stone Bridge">
-<sound>Stone 2Foot</sound>
-<point1>108,85</point1>
-<point2>120,85</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Tiny Boat 1">
-<sound>Wood 2Foot</sound>
-<point1>109,116</point1>
-<point2>110,119</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Tiny Boat 2">
-<sound>Wood 2Foot</sound>
-<point1>114,113</point1>
-<point2>114,117</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Tiny Boat 3">
-<sound>Wood 2Foot</sound>
-<point1>115,113</point1>
-<point2>116,119</point2>
-</walk_boundary_def>
+	<walk_boundary_def location="Boat 1">
+		<sound>Wood 2Foot</sound>
+		<point1>240,341</point1>
+		<point2>246,355</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Docks and Other Boats">
+		<sound>Wood 2Foot</sound>
+		<point1>247,330</point1>
+		<point2>285,358</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone Bridge 1">
+		<sound>Stone 2Foot</sound>
+		<point1>92,48</point1>
+		<point2>99,50</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone Bridge 2">
+		<sound>Stone 2Foot</sound>
+		<point1>122,47</point1>
+		<point2>130,49</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Small Boat">
+		<sound>Wood 2Foot</sound>
+		<point1>116,72</point1>
+		<point2>118,78</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Large Stone Bridge">
+		<sound>Stone 2Foot</sound>
+		<point1>108,85</point1>
+		<point2>120,85</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Tiny Boat 1">
+		<sound>Wood 2Foot</sound>
+		<point1>109,116</point1>
+		<point2>110,119</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Tiny Boat 2">
+		<sound>Wood 2Foot</sound>
+		<point1>114,113</point1>
+		<point2>114,117</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Tiny Boat 3">
+		<sound>Wood 2Foot</sound>
+		<point1>115,113</point1>
+		<point2>116,119</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="63" name="Iscalrith insides">
-<walk_boundary_def location="Cave with Walkway - Obelisk">
-<sound>Stone 2Foot</sound>
-<point1>536,140</point1>
-<point2>543,148</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Cave with Walkway Bottom">
-<sound>Stone 2Foot</sound>
-<point1>519,84</point1>
-<point2>555,139</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Cave with Walkway Mid">
-<sound>Stone 2Foot</sound>
-<point1>544,140</point1>
-<point2>554,163</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Cave with Walkway Top">
-<sound>Stone 2Foot</sound>
-<point1>531,163</point1>
-<point2>548,194</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Ice Bridge">
-<sound>Stone 2Foot</sound>
-<point1>299,92</point1>
-<point2>326,111</point2>
-</walk_boundary_def>
+<map file_name="./maps/cont2map24_insides.elm" name="Iscalrith insides">
+	<walk_boundary_def location="Cave with Walkway - Obelisk">
+		<sound>Stone 2Foot</sound>
+		<point1>536,140</point1>
+		<point2>543,148</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Cave with Walkway Bottom">
+		<sound>Stone 2Foot</sound>
+		<point1>519,84</point1>
+		<point2>555,139</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Cave with Walkway Mid">
+		<sound>Stone 2Foot</sound>
+		<point1>544,140</point1>
+		<point2>554,163</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Cave with Walkway Top">
+		<sound>Stone 2Foot</sound>
+		<point1>531,163</point1>
+		<point2>548,194</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Ice Bridge">
+		<sound>Stone 2Foot</sound>
+		<point1>299,92</point1>
+		<point2>326,111</point2>
+	</walk_boundary_def>
 </map>
-
-
-<map id="1" name="c2 docks irilion">
-<walk_boundary_def location="Bridge over water">
-<sound>Wood 2Foot</sound>
-<point1>65,43</point1>
-<point2>70,52</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stairway to exit">
-<sound>Wood 2Foot</sound>
-<point1>21,38</point1>
-<point2>30,47</point2>
-</walk_boundary_def>
+<map file_name="./maps/c2_docks_irillion.elm" name="c2 docks irilion">
+	<walk_boundary_def location="Bridge over water">
+		<sound>Wood 2Foot</sound>
+		<point1>65,43</point1>
+		<point2>70,52</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stairway to exit">
+		<sound>Wood 2Foot</sound>
+		<point1>21,38</point1>
+		<point2>30,47</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="3" name="c2 portals room">
-<walk_boundary_def location="entire portals room">
-<sound>Stone 2Foot</sound>
-<point1>0,0</point1>
-<point2>172,191</point2>
-</walk_boundary_def>
+<map file_name="./maps/c2_portalsroom.elm" name="c2 portals room">
+	<walk_boundary_def location="entire portals room">
+		<sound>Stone 2Foot</sound>
+		<point1>0,0</point1>
+		<point2>172,191</point2>
+	</walk_boundary_def>
 </map>
-
-<map id="4" name="the underworld">
-<boundary_def>
-	<background>Atmosphere Underworld</background>
-	<time_of_day_flags>0xffff</time_of_day_flags>
-	<is_default>1</is_default>
-</boundary_def>
-<walk_boundary_def location="Stone platforms over lava">
-<sound>Stone 2Foot</sound>
-<point1>134,53</point1>
-<point2>173,101</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone platform over lava">
-<sound>Stone 2Foot</sound>
-<point1>126,102</point1>
-<point2>147,112</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone bridge over lava">
-<sound>Stone 2Foot</sound>
-<point1>108,85</point1>
-<point2>132,87</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone platform on lava">
-<sound>Stone 2Foot</sound>
-<point1>126, 37</point1>
-<point2>131,42</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone platform on lava">
-<sound>Stone 2Foot</sound>
-<point1>138,53</point1>
-<point2>143,58</point2>
-</walk_boundary_def>
-
-<walk_boundary_def location="Stone walk on lava">
-<sound>Stone 2Foot</sound>
-<point1>97,125</point1>
-<point2>99,145</point2>
-</walk_boundary_def>
+<map file_name="./maps/c2_underworld.elm" name="the underworld">
+	<boundary_def>
+		<background>Atmosphere Underworld</background>
+		<time_of_day_flags>0xffff</time_of_day_flags>
+		<is_default>1</is_default>
+	</boundary_def>
+	<walk_boundary_def location="Stone platforms over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>134,53</point1>
+		<point2>173,101</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone platform over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>126,102</point1>
+		<point2>147,112</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone bridge over lava">
+		<sound>Stone 2Foot</sound>
+		<point1>108,85</point1>
+		<point2>132,87</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone platform on lava">
+		<sound>Stone 2Foot</sound>
+		<point1>126, 37</point1>
+		<point2>131,42</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone platform on lava">
+		<sound>Stone 2Foot</sound>
+		<point1>138,53</point1>
+		<point2>143,58</point2>
+	</walk_boundary_def>
+	<walk_boundary_def location="Stone walk on lava">
+		<sound>Stone 2Foot</sound>
+		<point1>97,125</point1>
+		<point2>99,145</point2>
+	</walk_boundary_def>
 </map>

--- a/interface.c
+++ b/interface.c
@@ -1075,7 +1075,7 @@ void draw_game_map (int map, int mouse_mini)
 #ifdef DEBUG_MAP_SOUND
 	// If we are in map view (not continent view) draw the sound area boundaries
 	if (map) {
-		print_sound_boundaries(cur_tab_map);
+		print_sound_boundaries(map_file_name);
 	}
 #endif // DEBUG_MAP_SOUND
 

--- a/map.c
+++ b/map.c
@@ -244,7 +244,7 @@ void change_map (const char *mapname)
 
 #ifdef NEW_SOUND
 	get_map_playlist();
-	setup_map_sounds(get_cur_map(mapname));
+	setup_map_sounds(mapname);
 #endif // NEW_SOUND
 	have_a_map=1;
 	//also, stop the rain
@@ -271,7 +271,7 @@ void change_map (const char *mapname)
 
 #ifdef NEW_SOUND
 	get_map_playlist();
-	setup_map_sounds(get_cur_map(mapname));
+	setup_map_sounds(mapname);
 #endif // NEW_SOUND
 	have_a_map=1;
 #endif  //MAP_EDITOR2

--- a/map.h
+++ b/map.h
@@ -159,7 +159,15 @@ extern int marks_3d;
 #define MARK_CLIP_POS 20
 #define MARK_DIST 20
 
-
+/*
+ * Returns the index of the map file name in the continent_maps array.
+ * This is used in map.c to save the index of the current map in cur_map.
+ * It is here temporarily because if the map sound config files use the map id rather than
+ * the map name from the server, sound.c needs to look up the index of the current map.
+ * Once map sound config files use server map name rather than id, we can remove this and
+ * references to get_cur_map in sound.c.
+ */
+int get_cur_map (const char * file_name);
 
 
 #ifdef __cplusplus

--- a/sound.c
+++ b/sound.c
@@ -203,7 +203,7 @@ typedef struct
 
 typedef struct
 {
-	int id;
+	char file_name[256];
 	char name[MAX_SOUND_MAP_NAME_LENGTH];		// This isn't used, it is simply helpful when editing the config
 	map_sound_boundary_def boundaries[MAX_SOUND_MAP_BOUNDARIES];		// This is the boundaries for backgound and crowd sounds
 	map_sound_boundary_def walk_boundaries[MAX_SOUND_WALK_BOUNDARIES];	// This is the boundaries for walking sounds (to fake 3d objects)
@@ -406,7 +406,7 @@ int sound_bounds_check(int x, int y, map_sound_boundary_def * bounds);
 int test_bounds_angles(int x, int y, int point, map_sound_boundary_def * bounds);
 double calculate_bounds_angle(int x, int y, int point, map_sound_boundary_def * bounds);
 #ifdef DEBUG_MAP_SOUND
-void print_sound_boundary_coords(int map);
+void print_sound_boundary_coords(const char *mapname);
 #endif // DEBUG_MAP_SOUND
 /* Init functions */
 void parse_snd_devices(ALCchar * in_array, char * sound_devs);
@@ -1083,7 +1083,7 @@ int check_for_valid_stream_sound(int tx, int ty, int type)
 {
 	int i, j, snd = -1, playing, found = 0;
 
-	if (snd_cur_map > -1 && sound_map_data[snd_cur_map].id > -1)
+	if (snd_cur_map > -1 && sound_map_data[snd_cur_map].file_name[0] != '\0')
 	{
 		for (i = 0; i < sound_map_data[snd_cur_map].num_boundaries; i++)
 		{
@@ -3336,7 +3336,7 @@ int get_boundary_walk_sound(int tx, int ty)
 {
 	int i, snd = -1;
 
-	if (snd_cur_map > -1 && sound_map_data[snd_cur_map].id > -1)
+	if (snd_cur_map > -1 && sound_map_data[snd_cur_map].file_name[0] != '\0')
 	{
 		for (i = 0; i < sound_map_data[snd_cur_map].num_walk_boundaries; i++)
 		{
@@ -3405,25 +3405,25 @@ int get_tile_sound(int tile_type, char * actor_type)
 }
 
 
-void setup_map_sounds (int map_num)
+void setup_map_sounds (const char * mapname)
 {
 	int i;
 #ifdef DEBUG_MAP_SOUND
 	char str[100];
-	safe_snprintf(str, sizeof(str), "Map number: %d", map_num);
+	safe_snprintf(str, sizeof(str), "Map file name: %s", mapname);
 	LOG_TO_CONSOLE(c_red1, str);
 #endif // DEBUG_MAP_SOUND
 	// Find the index for this map in our data
 	snd_cur_map = -1;
 	for (i = 0; i < sound_num_maps; i++)
 	{
-		if (map_num == sound_map_data[i].id)
+		if (strcmp (sound_map_data[i].file_name, mapname) == 0)
 		{
 			snd_cur_map = i;
 #ifdef DEBUG_MAP_SOUND
-			safe_snprintf(str, sizeof(str), "Snd config map ID: %d, Snd config map name: %s", sound_map_data[i].id, sound_map_data[i].name);
+			safe_snprintf(str, sizeof(str), "Snd config map name: %s", sound_map_data[i].name);
 			LOG_TO_CONSOLE(c_red1, str);
-			print_sound_boundary_coords(map_num);
+			print_sound_boundary_coords(mapname);
 #endif // DEBUG_MAP_SOUND
 			return;
 		}
@@ -3699,16 +3699,16 @@ double calculate_bounds_angle(int x, int y, int point, map_sound_boundary_def * 
 //
 // It is a known bug that this _does not_ scale to the map selected. The scale will stay the same as your currently loaded map!
 //
-void print_sound_boundaries(int map)
+void print_sound_boundaries(const char *mapname)
 {
 	int i, i_max, j, id = -1, scale = 6, num_def = 0;
-	char buf[100];
+	char buf[256];
 	map_sound_boundary_def *bounds;
 	bound_point p[4];
 
 	// Check if this map matches an array id
 	for (i = 0; i < MAX_SOUND_MAPS; i++) {
-		if (map == sound_map_data[i].id) {
+		if (strcmp (sound_map_data[i].file_name, mapname) == 0) {
 			id = i;
 			break;
 		}
@@ -3722,9 +3722,9 @@ void print_sound_boundaries(int map)
 	
 	glEnable (GL_TEXTURE_2D);
 	glColor3f (1.0f, 1.0f, 1.0f);
-	safe_snprintf(buf, sizeof(buf), "Map Num: %d, Array ID: %d, Map Name: %s\nNum Bound: %d (%d def), Num Walk: %d", map, id, sound_map_data[id].name, 
+	safe_snprintf(buf, sizeof(buf), "Map File Name: %s, Array ID: %d\nMap Name: %s\nNum Bound: %d (%d def), Num Walk: %d", mapname, id, sound_map_data[id].name, 
 				  sound_map_data[id].num_boundaries, num_def, sound_map_data[id].num_walk_boundaries);
-	draw_string_zoomed(25, 180, (unsigned char*)buf, 2, 0.4);
+	draw_string_zoomed_width_font(main_map_screen_x_left, main_map_screen_y_bottom/10, (unsigned char*)buf, main_map_screen_x_right-main_map_screen_x_left,3,UI_FONT, get_global_scale());
 	glDisable(GL_TEXTURE_2D);
 	glBegin(GL_LINES);
 	// Draw boundaries for this map
@@ -3784,21 +3784,21 @@ void print_sound_boundaries(int map)
 }
 
 // Prints the sound boundary coords for the input map to stdout
-void print_sound_boundary_coords(int map)
+void print_sound_boundary_coords(const char *mapname)
 {
 	int i, i_max, j, id = -1;
 	map_sound_boundary_def *bounds;
 
 	// Check if this map matches an array id
 	for (i = 0; i < MAX_SOUND_MAPS; i++) {
-		if (map == sound_map_data[i].id) {
+		if (strcmp (sound_map_data[i].file_name, mapname) == 0) {
 			id = i;
 			break;
 		}
 	}
 	if (id == -1) return;	// Didn't find the map in our array so bail
 	
-	printf("Map Num: %d, Array ID: %d, Map Name: %s, ", map, id, sound_map_data[id].name);
+	printf("Map File Name: %s, Array ID: %d, Map Name: %s, ", mapname, id, sound_map_data[id].name);
 	// Print boundaries for this map
 	for (j = 0; j < 2; j++) {
 		if (j == 0) {
@@ -3924,7 +3924,7 @@ void clear_sound_data()
 	walking_default = -1;
 	for (i = 0; i < MAX_SOUND_MAPS; i++)
 	{
-		sound_map_data[i].id = -1;
+		sound_map_data[i].file_name[0] = '\0';
 		sound_map_data[i].name[0] = '\0';
 		sound_map_data[i].num_boundaries = 0;
 		for (j = 0; j < MAX_SOUND_MAP_BOUNDARIES; j++)
@@ -4116,7 +4116,7 @@ void initial_sound_init(void)
 	for (i=0; i<MAX_SOUND_MAPS; i++)
 	{
 		sound_map_data[i].num_boundaries = sound_map_data[i].num_defaults = sound_map_data[i].num_walk_boundaries = 0;
-		sound_map_data[i].id = -1;
+		sound_map_data[i].file_name[0] = '\0';
 	}
 
 	// as clear_sound_data()
@@ -5126,15 +5126,15 @@ void parse_map_sound(const xmlNode *inNode)
 	}
 	pMap = &sound_map_data[sound_num_maps++];
 
-	sVal = xmlGetProp((xmlNode*)inNode,(const xmlChar*)"id");
+	sVal = xmlGetProp((xmlNode*)inNode,(const xmlChar*)"file_name");
 	if (!sVal)
 	{
-		pMap->id = -1;
-		LOG_ERROR("%s: map has no id", snd_config_error);
+		pMap->file_name[0] = '\0';
+		LOG_ERROR("%s: map has no file_name", snd_config_error);
 	}
 	else
 	{
-		pMap->id = atoi((const char*)sVal);
+		safe_strncpy(pMap->file_name, (const char*)sVal, sizeof(pMap->file_name));
 		xmlFree(sVal);
 
 		sVal = xmlGetProp((xmlNode*)inNode, (const xmlChar*)"name");

--- a/sound.h
+++ b/sound.h
@@ -121,7 +121,7 @@ void toggle_sounds(int *var);
  */
 void disable_sound(int *var);
 
-void setup_map_sounds (int map_num);
+void setup_map_sounds (const char * mapname);
 
 /*!
  * \ingroup sound_effects
@@ -302,7 +302,7 @@ void handle_walking_sound(actor *pActor, int def_snd);
 int check_sound_loops(unsigned int cookie);
 void check_sound_alerts(const Uint8* text, size_t len, Uint8 channel);
 #ifdef DEBUG_MAP_SOUND
-void print_sound_boundaries(int map);
+void print_sound_boundaries(const char * mapname);
 #endif // DEBUG_MAP_SOUND
 
 static __inline__ void do_click_sound(){


### PR DESCRIPTION
Update map sound config files to use the map file name rather than the map array index number.
Update the client code to read map sound config files that use either the map file name or the map array index number.  Keeping the functionality to read map sound config files that use map array index number is for backwards compatbility with older map sound config files.
