### PR TITLE
Improved URL parsing

### DIFF
--- a/url.c
+++ b/url.c
@@ -225,7 +225,7 @@ int is_url_end_delim(unsigned char chr)
 	int i;
 	
 	// character is not ascii graphic
-	if (!(chr >= 0x20 && chr <= 0x7E))
+	if (!(isascii(chr) && isprint(chr)))
 		return 1;
 		
 	for (i=0; i < sizeof(non_url_printable_chars); i++)

--- a/url.c
+++ b/url.c
@@ -41,7 +41,6 @@
 #endif
 #include "sound.h"
 
-#define MIN(a,b) (((a)<(b))?(a):(b))
 
 char browser_name[120];
 static Uint32 url_win_sep = 0;
@@ -253,8 +252,8 @@ void find_all_url(const char *source_string, const int len)
 		{
 			const char* ptr = safe_strcasestr(source_string+next_start, len-next_start, search_for[i], strlen(search_for[i]));
 			if (ptr && ptr - (source_string + next_start) < first_found)
-				if (strncmp(ptr, "www.", MIN(len,4)) != 0
-					|| (strncmp(ptr, "www.", MIN(len,4)) == 0
+				if (strncmp(ptr, "www.", 4) != 0
+					|| (strncmp(ptr, "www.", 4) == 0
 						&& (ptr == source_string || (ptr > source_string && !isalpha(*(ptr-1))))
 					)
 				)


### PR DESCRIPTION
When parsing URLs there must be a non-alpha character to delimit the start of a URL and what's included in the URL more closely follows rfc1738.