### PR TITLE
Fix water reflection on Windows/Virtualbox/Intel graphics

### DIFF
--- a/init.c
+++ b/init.c
@@ -1117,6 +1117,8 @@ void init_stuff(void)
 	skybox_init_gl();
 	popup_init();
 
+	check_flip_fbo_texture();
+
 	DO_CHECK_GL_ERRORS();
 	LOG_DEBUG("Init done!");
 }

--- a/reflection.h
+++ b/reflection.h
@@ -14,6 +14,16 @@ extern float water_movement_u; /**< movement of the water in u direction */
 extern float water_movement_v; /**< movement of the water in v direction */
 extern int water_shader_quality; /**< quality of the shader used for drawing water. Zero means no shader. */
 
+/*!
+ * \brief Check if the texture coordinates for the reflection buffer should be flipped
+ *
+ * On some systems (e.g. Intel integrated graphics on Windows), the reflection texture is rendered
+ * upside down (or interpreted to be such), so that the texture coordinates must be flipped
+ * vertically to render the water reflection correctly. This function determines if this must be
+ * done.
+ */
+void check_flip_fbo_texture(void);
+
 /**
  * defines whether a tile is a water tile or not
  */

--- a/shaders/reflectiv_water_fs.glsl
+++ b/shaders/reflectiv_water_fs.glsl
@@ -44,7 +44,10 @@ void main (void)
 
 	noise_diplacment = texture3D(noise_texture, noise_tex_coord).ga * 2.0 - 1.0;
 
-	reflection_tex_coord += noise_diplacment * noise_scale.xy;
+	// Next line does not play nice on VirtualBox/Windows/Intel HD 530. Why? No idea.
+	//reflection_tex_coord += noise_diplacment * noise_scale.xy;
+	reflection_tex_coord = vec2(reflection_tex_coord.x + noise_diplacment.x * noise_scale.x,
+		reflection_tex_coord.y + noise_diplacment.y * noise_scale.y);
 	tile_tex_coord += noise_diplacment * noise_scale.zw;
 #endif	// USE_NOISE
 


### PR DESCRIPTION
Fix a number of issues with the water reflection running the client on a Windows client in Virtualbox:
* The framebuffer texture is interpreted upside down by the VirtualBox driver. This is an issue that has been
encountered in other programs as well, notably on Intel integrated graphics chipsets. Fix this by detecting
if this is the case by generating a known texture and checking its contents, and flipping the scene vertically
if it occurs.
* The OpenGL implementation seems to have trouble with the water shader using a vectored multiply-add-assign
operation. Explicitly constructing a new vec2 from separate components seems to solve the issue somehow. Though I
am no expert in GLSL, the existing code certainly looks valid, so this seems to point to another driver bug.

Posting this as a pull request, so that people may check if it does not have any unwanted side effects. As far as I can tell, there should be none: the first fix should not affect properly behaving systems, and the second just rewrites the same assignment in separate components. I have tested this also in Linux, which was working correctly before, and have observed no change in behaviour. Nevertheless, better get some other testing in before we break an existing setup.