### PR TITLE
Try to scale and center objects inside the 3d object browser of the map editor

### DIFF
--- a/map_editor/3d_objects.h
+++ b/map_editor/3d_objects.h
@@ -4,6 +4,7 @@
 #include "e3d.h"
 
 void draw_3d_object(object3d * object_id);
+void draw_3d_object_in_browser(object3d * object_id);
 e3d_object * load_e3d_cache(char * file_name);
 int add_e3d (char * file_name, float x_pos, float y_pos, float z_pos, float x_rot, float y_rot, float z_rot, char self_lit, char blended, float r, float g, float b);
 int add_e3d_keep_deleted (char * file_name, float x_pos, float y_pos, float z_pos, float x_rot, float y_rot, float z_rot, char self_lit, char blended, float r, float g, float b);

--- a/map_editor/browser.c
+++ b/map_editor/browser.c
@@ -256,8 +256,8 @@ int display_browser_handler(window_info *win)
 		valid_object=setobject(0,fn,Dir[cd].xrot[i],Dir[cd].yrot[i],Dir[cd].zrot[i]);
 		if(valid_object){
 			glPushMatrix();
-			glScalef(Dir[cd].size[i],Dir[cd].size[i],Dir[cd].size[i]);
-			draw_3d_object(&o3d[0]);
+			//glScalef(Dir[cd].size[i],Dir[cd].size[i],Dir[cd].size[i]);
+            draw_3d_object_in_browser(&o3d[0]);
 			glPopMatrix();
 		}
 		
@@ -275,8 +275,8 @@ int display_browser_handler(window_info *win)
 			valid_object=setobject(1,fn,Dir[cd].xrot[i+1],Dir[cd].yrot[i+1],Dir[cd].zrot[i+1]);
 			if(valid_object){
 				glPushMatrix();
-				glScalef(Dir[cd].size[i+1],Dir[cd].size[i+1],Dir[cd].size[i+1]);
-				draw_3d_object(&o3d[1]);
+				//glScalef(Dir[cd].size[i+1],Dir[cd].size[i+1],Dir[cd].size[i+1]);
+                draw_3d_object_in_browser(&o3d[1]);
 				glPopMatrix();
 			}
 		}
@@ -295,8 +295,8 @@ int display_browser_handler(window_info *win)
 			valid_object=setobject(2,fn,Dir[cd].xrot[i+2],Dir[cd].yrot[i+2],Dir[cd].zrot[i+2]);
 			if(valid_object){
 				glPushMatrix();
-				glScalef(Dir[cd].size[i+2],Dir[cd].size[i+2],Dir[cd].size[i+2]);
-				draw_3d_object(&o3d[2]);
+				//glScalef(Dir[cd].size[i+2],Dir[cd].size[i+2],Dir[cd].size[i+2]);
+                draw_3d_object_in_browser(&o3d[2]);
 				glPopMatrix();
 			}
 		}
@@ -315,8 +315,8 @@ int display_browser_handler(window_info *win)
 			valid_object=setobject(3,fn,Dir[cd].xrot[i+3],Dir[cd].yrot[i+3],Dir[cd].zrot[i+3]);
 			if(valid_object){
 				glPushMatrix();
-				glScalef(Dir[cd].size[i+3],Dir[cd].size[i+3],Dir[cd].size[i+3]);
-				draw_3d_object(&o3d[3]);
+				//glScalef(Dir[cd].size[i+3],Dir[cd].size[i+3],Dir[cd].size[i+3]);
+                draw_3d_object_in_browser(&o3d[3]);
 				glPopMatrix();
 			}
 		}


### PR DESCRIPTION
There's something that has been bothering me for awhile now regarding the map editor 3d object browser.
The objects are not always visible, or not centered, in the 3d object browser.
From what I could understand from the code, the behavior depends on the size of the object.

I'm trying to play around with a scale factor to place the object inside the "canvas" always centered and scaled to fit the 3d browser window.

This is not finished yet, but I would like some comments if you have any :slightly_smiling_face: 
Also if you can test and confirm you see no issue it would be great.

Once we agree what would be the best approach to improve this I can rework the pull request.
