### PR TITLE
Update map_editor/e3d.c

### DIFF
--- a/map_editor/e3d.c
+++ b/map_editor/e3d.c
@@ -91,7 +91,7 @@ void set_emission(object3d * object_id)
 {
 	if(object_id->self_lit && (night_shadows_on || dungeon))
 	{
-		glDisable(GL_LIGHTING);
+		glEnable(GL_LIGHTING);
 		glMaterialfv(GL_FRONT, GL_EMISSION, object_id->color);
 	}
 	else


### PR DESCRIPTION
Enable self-lit items to actually self-light in the map editor under correct circumstances (dungeon/internal maps). See https://github.com/raduprv/Eternal-Lands/issues/188