### PR TITLE
Automated build checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,108 @@
+name: Build check
+on: 
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - master
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: "Checkout repo"
+      uses: actions/checkout@v3
+      with:
+        submodules: "recursive"
+        fetch-depth: 0
+
+    - name: "Install dependencies"
+      run: |
+        sudo apt update -qq
+        sudo apt install -y cmake libsdl2-dev libsdl2-net-dev libsdl2-image-dev libssl-dev libopenal-dev libcal3d12-dev libvorbis-dev libsdl2-ttf-dev
+    
+    - name: "cmake"
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=release -DLOCAL_NLOHMANN_JSON=ON
+        
+    - name: "compile"
+      run: |
+        cmake --build build
+
+  build-ubuntu-mapeditor:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: "Checkout repo"
+      uses: actions/checkout@v3
+      with:
+        submodules: "recursive"
+        fetch-depth: 0
+
+    - name: "Install dependencies"
+      run: |
+        sudo apt update -qq
+        sudo apt install -y cmake libsdl1.2-dev libsdl-image1.2-dev libopenal-dev libcal3d12-dev nlohmann-json3-dev libx11-dev libgtk2.0-dev
+    
+    - name: "cmake"
+      working-directory: ./map_editor
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=release -DLOCAL_NLOHMANN_JSON=ON
+        
+    - name: "compile"
+      working-directory: ./map_editor
+      run: |
+        cmake --build build
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+          fetch-depth: 0
+
+      - name: "Setup MSYS2 environment"
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-SDL2
+            mingw-w64-x86_64-SDL2_net
+            mingw-w64-x86_64-SDL2_image
+            mingw-w64-x86_64-openssl
+            mingw-w64-x86_64-openal
+            mingw-w64-x86_64-libvorbis
+            mingw-w64-x86_64-SDL2_ttf
+            mingw-w64-x86_64-libxml2
+
+      - name: "Download and install cal3d from source"
+        shell: msys2 {0}
+        run: |
+          wget https://github.com/raduprv/Eternal-Lands/releases/download/1.9.5.2/cal3d-0.11.0.tar.gz
+          wget https://github.com/raduprv/Eternal-Lands/releases/download/1.9.5.2/cal3d-0.11.0-patch
+          tar xfz cal3d-0.11.0.tar.gz
+          cd cal3d-0.11.0/
+          patch -p1 < ../cal3d-0.11.0-patch
+          export "CFLAGS=-I${PACKAGELOCAL}/include -O3"
+          export "CPPFLAGS=-I${PACKAGELOCAL}/include -O3"
+          export "LDFLAGS=-L${PACKAGELOCAL}/lib"
+          export "PKG_CONFIG_PATH=${PACKAGELOCAL}/lib/pkgconfig"
+          ./configure --prefix=${PACKAGELOCAL} && make && make install-strip
+
+      - name: "cmake"
+        shell: msys2 {0}
+        run: |
+          cmake -G "MinGW Makefiles" -S . -B build -DCMAKE_BUILD_TYPE=release -DLOCAL_NLOHMANN_JSON=ON
+        
+      - name: "compile"
+        shell: msys2 {0}
+        run: |
+          cmake --build build


### PR DESCRIPTION
Hi again,
from what I understand, and please correct me if I am wrong, the process of testing whether builds still compile or not is all done manually right now for the Eternal Lands client and the map editor.

Therefore I propose to add automated build testing via [github workflows](https://docs.github.com/en/actions/automating-builds-and-tests/about-continuous-integration#about-continuous-integration-using-github-actions) to help catch compile errors and other build problems automatically. If you are not familiar with the concept of CI, a very simplified explanation is that workflows allow you to run arbitrary scripts automatically as a response to commits, pushes or other git events. A common use case is verifying if the codebase still builds on all targeted platforms after each commit and before a PR is merged. Github workflows are also nicely integrated into the web UI. 

As a visual example, for a pull request the workflow results are displayed like this (screenshot taken from another project):
![image](https://github.com/raduprv/Eternal-Lands/assets/13877693/2b8faabf-23a0-4fab-b829-bc45ed75b5df)

Virtually all bigger projects on github use CI workflows already since it's a really nice convenience feature and free of cost for public repositories. For an additional demonstration you can take a look at OpenTTD's [commit list](https://github.com/OpenTTD/OpenTTD/commits/master/) (click on the little green check marks) or any of their [pull requests](https://github.com/OpenTTD/OpenTTD/pulls).

Since you can run arbitrary scripts it makes workflows very flexible. In my other projects we use this to generate downloadable binaries for each commit or PR, so developers and users can quickly test a new change and raise an issue if something breaks. We also have a "release" workflow which is manually triggered and compiles all the builds, packages them and automatically creates a draft github release.

With this PR I added an initial workflow that simply verifies if the following configurations still build successfully:
- Eternal Lands client on Ubuntu
- Eternal Lands client on Windows via msys
- Map Editor on Ubuntu
 
Other configurations are still missing (android, macos, appimage, windows map editor, etc.) because I didn't want to invest too much time yet in case this gets rejected. If approved, I can look into adding more build targets. Also, I am available to help maintain this in the future but generally once its setup it doesn't really break or need much attention.

As a side note, I considered asking via issue first if you even want this, but it's easier to just demonstrate it than to explain the theory behind it. Looking forward to your thoughts and I hope you can see the value in automated build testing. If you have any questions let me know.