### PR TITLE
Add `-ld_classic` linker flag so build succeeds on Xcode 15

### DIFF
--- a/macosx/Eternal Lands.xcodeproj/project.pbxproj
+++ b/macosx/Eternal Lands.xcodeproj/project.pbxproj
@@ -1828,6 +1828,7 @@
 					"-lc",
 					"-lstdc++",
 					"-liconv",
+					"-ld_classic",
 				);
 				SDKROOT = macosx;
 				VALIDATE_WORKSPACE_SKIPPED_SDK_FRAMEWORKS = OpenGL;
@@ -1889,6 +1890,7 @@
 					"-lc",
 					"-lstdc++",
 					"-liconv",
+					"-ld_classic",
 				);
 				SDKROOT = macosx;
 				VALIDATE_WORKSPACE_SKIPPED_SDK_FRAMEWORKS = OpenGL;


### PR DESCRIPTION
Fixes #210.

The latest macos image uses Xcode 15, which introduces a new linker: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking

I added the `-ld_classic` linker flag recommended there to revert back to the old linker and it seems to fix things. We'll need to drop this flag at some point though, since it sounds like it will be removed in a future Xcode release.

@pjbroad @bendoughty 