### PR TITLE
Slider widget for options window

### DIFF
--- a/elconfig.c
+++ b/elconfig.c
@@ -2134,6 +2134,7 @@ static int context_option_handler(window_info *win, int widget_id, int mx, int m
 	{
 		case OPT_INT:
 		case OPT_INT_F:
+        case OPT_INT_S:
 			set_var_OPT_INT(option->name, (int)new_value);
 			break;
 		case OPT_MULTI:
@@ -2144,6 +2145,7 @@ static int context_option_handler(window_info *win, int widget_id, int mx, int m
 			set_var_OPT_BOOL(option->name, (int)new_value);
 			break;
 		case OPT_FLOAT:
+        case OPT_FLOAT_S:
 			set_var_OPT_FLOAT(option->name, new_value);
 			break;
 		default:
@@ -2160,6 +2162,7 @@ static int add_cm_option_line(const char *prefix, var_struct *option, float valu
 	{
 		case OPT_INT:
 		case OPT_INT_F:
+        case OPT_INT_S:
 		case OPT_MULTI:
 		case OPT_MULTI_H:
 			safe_snprintf(menu_text, sizeof(menu_text), "\n%s: %d\n", prefix, (int)value);
@@ -2168,6 +2171,7 @@ static int add_cm_option_line(const char *prefix, var_struct *option, float valu
 			safe_snprintf(menu_text, sizeof(menu_text), "\n%s: %s\n", prefix, ((int)value) ?"true": "false");
 			break;
 		case OPT_FLOAT:
+        case OPT_FLOAT_S:
 			safe_snprintf(menu_text, sizeof(menu_text), "\n%s: %g\n", prefix, value);
 			break;
 		default:

--- a/elconfig.c
+++ b/elconfig.c
@@ -213,6 +213,7 @@ typedef struct
 	{
 		struct { int min; int max; } imm;
 		struct { int (*min)(); int (*max)(); } immf;
+        struct { float min; float max; } fmm;
 		struct { float min; float max; float interval; } fmmi;
 		struct { float (*min)(); float (*max)(); float interval; } fmmif;
 		struct { multi_element *elems; size_t count; } multi;
@@ -1904,58 +1905,93 @@ int toggle_OPT_BOOL_by_name(const char *str)
 // find an OPT_INT ot OPT_INT_F widget and set its's value
 int set_var_OPT_INT(const char *str, int new_value)
 {
-	int var_index = find_var(str, INI_FILE_VAR);
+    int var_index = find_var(str, INI_FILE_VAR);
 
-	if ((var_index != -1) && ((our_vars.var[var_index]->type == OPT_INT) || (our_vars.var[var_index]->type == OPT_INT_F)))
-	{
-		int tab_win_id = elconfig_tabs[our_vars.var[var_index]->widgets.tab_id].tab;
-		int widget_id = our_vars.var[var_index]->widgets.widget_id;
-		// This bit belongs in the widgets module
-		widget_list *widget = widget_find(tab_win_id, widget_id);
-		our_vars.var[var_index]->func(our_vars.var[var_index]->var, new_value);
-		our_vars.var[var_index]->saved = 0;
-		if(widget != NULL && widget->widget_info != NULL)
-		{
-			spinbutton *button = widget->widget_info;
-			*(int *)button->data = new_value;
-			safe_snprintf(button->input_buffer, sizeof(button->input_buffer), "%i", *(int *)button->data);
-			return 1;
-		}
+    if ((var_index != -1) && ((our_vars.var[var_index]->type == OPT_INT) || (our_vars.var[var_index]->type == OPT_INT_F) || (our_vars.var[var_index]->type == OPT_INT_S)))
+    {
+        int tab_win_id = elconfig_tabs[our_vars.var[var_index]->widgets.tab_id].tab;
+        int widget_id = our_vars.var[var_index]->widgets.widget_id;
+        // This bit belongs in the widgets module
+        widget_list *widget = widget_find(tab_win_id, widget_id);
+        our_vars.var[var_index]->func(our_vars.var[var_index]->var, new_value);
+        our_vars.var[var_index]->saved = 0;
+        
+        if(our_vars.var[var_index]->type == OPT_INT_S)
+        {
+            if(widget != NULL && widget->widget_info != NULL)
+            {
+                slider *s = widget->widget_info;
+                *(int *)s->data = new_value;
+                safe_snprintf(s->input_buffer, sizeof(s->input_buffer), "%i", *(int *)s->data);
+                
+                // Force a position update for the slider
+                s->pos = ((new_value - s->min) * 100) / (s->max - s->min);
+                return 1;
+            }
+        }
+        else
+        {
+            if(widget != NULL && widget->widget_info != NULL)
+            {
+                spinbutton *button = widget->widget_info;
+                *(int *)button->data = new_value;
+                safe_snprintf(button->input_buffer, sizeof(button->input_buffer), "%i", *(int *)button->data);
+                return 1;
+            }
+        }
 
-		return 0;
-	}
+        return 0;
+    }
 
-	LOG_ERROR("Can't find var '%s', type 'OPT_INT'", str);
-	return 0;
+    LOG_ERROR("Can't find var '%s', type 'OPT_INT'", str);
+    return 0;
 }
 
 // find an OPT_FLOAT widget and set its's value
 static int set_var_OPT_FLOAT(const char *str, float new_value)
 {
-	int var_index = find_var(str, INI_FILE_VAR);
+    int var_index = find_var(str, INI_FILE_VAR);
 
-	if ((var_index != -1) && (our_vars.var[var_index]->type == OPT_FLOAT))
-	{
-		int tab_win_id = elconfig_tabs[our_vars.var[var_index]->widgets.tab_id].tab;
-		int widget_id = our_vars.var[var_index]->widgets.widget_id;
-		// This bit belongs in the widgets module
-		widget_list *widget = widget_find(tab_win_id, widget_id);
-		our_vars.var[var_index]->func(our_vars.var[var_index]->var, &new_value);
-		our_vars.var[var_index]->saved = 0;
-		if(widget != NULL && widget->widget_info != NULL)
-		{
-			spinbutton *button = widget->widget_info;
-			*(float *)button->data = new_value;
-			safe_snprintf(button->input_buffer, sizeof(button->input_buffer), "%.2f", *(float *)button->data);
-			return 1;
-		}
+    if ((var_index != -1) && ((our_vars.var[var_index]->type == OPT_FLOAT) || (our_vars.var[var_index]->type == OPT_FLOAT_S)))
+    {
+        int tab_win_id = elconfig_tabs[our_vars.var[var_index]->widgets.tab_id].tab;
+        int widget_id = our_vars.var[var_index]->widgets.widget_id;
+        // This bit belongs in the widgets module
+        widget_list *widget = widget_find(tab_win_id, widget_id);
+        our_vars.var[var_index]->func(our_vars.var[var_index]->var, &new_value);
+        our_vars.var[var_index]->saved = 0;
+        
+        if(our_vars.var[var_index]->type == OPT_FLOAT_S)
+        {
+            if(widget != NULL && widget->widget_info != NULL)
+            {
+                slider *s = widget->widget_info;
+                *(float *)s->data = new_value;
+                safe_snprintf(s->input_buffer, sizeof(s->input_buffer), "%.2f", *(float *)s->data);
+                
+                // Force a position update for the slider
+                s->pos = ((new_value - s->min) * 100) / (s->max - s->min);
+                return 1;
+            }
+        }
+        else
+        {
+            if(widget != NULL && widget->widget_info != NULL)
+            {
+                spinbutton *button = widget->widget_info;
+                *(float *)button->data = new_value;
+                safe_snprintf(button->input_buffer, sizeof(button->input_buffer), "%.2f", *(float *)button->data);
+                return 1;
+            }
+        }
 
-		return 0;
-	}
+        return 0;
+    }
 
-	LOG_ERROR("Can't find var '%s', type 'OPT_FLOAT'", str);
-	return 0;
+    LOG_ERROR("Can't find var '%s', type 'OPT_FLOAT'", str);
+    return 0;
 }
+
 
 static int set_var_OPT_BOOL(const char *str, int new_value)
 {
@@ -2237,6 +2273,7 @@ static __inline__ void check_option_var(const char* name)
 		case OPT_MULTI:
 		case OPT_MULTI_H:
 		case OPT_INT_F:
+        case OPT_INT_S:
 		case OPT_INT_INI:
 			value_i= *((int*)our_vars.var[i]->var);
 			our_vars.var[i]->func (our_vars.var[i]->var, value_i);
@@ -2256,6 +2293,7 @@ static __inline__ void check_option_var(const char* name)
 			break;
 		case OPT_FLOAT:
 		case OPT_FLOAT_F:
+        case OPT_FLOAT_S:
 			value_f= *((float*)our_vars.var[i]->var);
 			our_vars.var[i]->func (our_vars.var[i]->var, value_f);
 			break;
@@ -2552,6 +2590,7 @@ int check_var(char *str, var_name_type type)
 			// fallthrough
 		case OPT_INT:
 		case OPT_INT_F:
+        case OPT_INT_S:
 		{
 			int new_val = atoi (ptr);
 			our_vars.var[i]->func(our_vars.var[i]->var, new_val);
@@ -2588,6 +2627,7 @@ int check_var(char *str, var_name_type type)
 			return 1;
 		case OPT_FLOAT:
 		case OPT_FLOAT_F:
+        case OPT_FLOAT_S:
 			foo= atof (ptr);
 			our_vars.var[i]->func (our_vars.var[i]->var, &foo);
 			our_vars.var[i]->config_file_val = foo;
@@ -2666,6 +2706,7 @@ static void add_var(option_type type, char * name, char * shortname, void * var,
 		break;
 		case OPT_INT:
 		case OPT_INT_INI:
+        case OPT_INT_S:
 			va_start(ap, tab_id);
 			our_vars.var[no]->args.imm.min = va_arg(ap, uintptr_t);
 			our_vars.var[no]->args.imm.max = va_arg(ap, uintptr_t);
@@ -2697,6 +2738,13 @@ static void add_var(option_type type, char * name, char * shortname, void * var,
 			va_end(ap);
 			*f = def;
 			break;
+        case OPT_FLOAT_S:
+            va_start(ap, tab_id);
+            our_vars.var[no]->args.fmm.min = va_arg(ap, double);
+            our_vars.var[no]->args.fmm.max = va_arg(ap, double);
+            va_end(ap);
+            *f=def;
+            break;
 		case OPT_INT_F:
 			va_start(ap, tab_id);
 			our_vars.var[no]->args.immf.min = va_arg(ap, int (*)());
@@ -3411,6 +3459,7 @@ static void write_var(FILE *fout, int ivar)
 		case OPT_INT:
 		case OPT_BOOL:
 		case OPT_INT_F:
+        case OPT_INT_S:
 		case OPT_BOOL_INI:
 		case OPT_INT_INI:
 		{
@@ -3445,6 +3494,7 @@ static void write_var(FILE *fout, int ivar)
 			break;
 		case OPT_FLOAT:
 		case OPT_FLOAT_F:
+        case OPT_FLOAT_S:
 		{
 			float *g = var->var;
 			fprintf(fout, "#%s= %g\n", var->name, *g);
@@ -3735,6 +3785,64 @@ static int spinbutton_onclick_handler(widget_list *widget, int mx, int my, Uint3
 	return 0;
 }
 
+static int slider_onclick_handler(widget_list *widget, int mx, int my, Uint32 flags)
+{
+    if(widget != NULL) {
+        int i;
+        slider *button;
+
+        for(i= 0; i < our_vars.no; i++) {
+            if(our_vars.var[i]->widgets.widget_id == widget->id) {
+                button= widget->widget_info;
+#ifdef ANDROID
+                if (mx < widget->len_x * 0.75)
+                    SDL_StartTextInput();
+#endif
+                switch(button->type) {
+                    case SLIDER_FLOAT:
+                        our_vars.var[i]->func(our_vars.var[i]->var, (float *)button->data);
+                    break;
+                    case SLIDER_INT:
+                        our_vars.var[i]->func(our_vars.var[i]->var, *(int *)button->data);
+                    break;
+                }
+                our_vars.var[i]->saved= 0;
+                return 0;
+            }
+        }
+    }
+    return 0;
+}
+
+static int slider_ondrag_handler(widget_list *widget, int mx, int my, Uint32 flags)
+{
+    if(widget != NULL) {
+        int i;
+        slider *button;
+
+        for(i= 0; i < our_vars.no; i++) {
+            if(our_vars.var[i]->widgets.widget_id == widget->id) {
+                button= widget->widget_info;
+#ifdef ANDROID
+                if (mx < widget->len_x * 0.75)
+                    SDL_StartTextInput();
+#endif
+                switch(button->type) {
+                    case SLIDER_FLOAT:
+                        our_vars.var[i]->func(our_vars.var[i]->var, (float *)button->data);
+                    break;
+                    case SLIDER_INT:
+                        our_vars.var[i]->func(our_vars.var[i]->var, *(int *)button->data);
+                    break;
+                }
+                our_vars.var[i]->saved= 0;
+                return 0;
+            }
+        }
+    }
+    return 0;
+}
+
 #ifdef ANDROID
 static int string_onclick_handler(widget_list *widget, int mx, int my, Uint32 flags)
 {
@@ -4007,6 +4115,9 @@ static int get_elconfig_content_width(void)
 	var_struct *var;
 	int spin_button_width = max2i(ELCONFIG_SCALED_VALUE(100),
 		4 * get_max_digit_width_zoom(CONFIG_FONT, elconf_scale) + 4 * (int)(0.5 + 5 * elconf_scale));
+    
+    int slider_width = max2i(ELCONFIG_SCALED_VALUE(200),
+        4 * get_max_digit_width_zoom(CONFIG_FONT, elconf_scale) + 4 * (int)(0.5 + 5 * elconf_scale));
 
 	for (i = 0; i < our_vars.no; i++)
 	{
@@ -4031,6 +4142,11 @@ static int get_elconfig_content_width(void)
 				line_width = get_string_width_zoom(var->display.str, CONFIG_FONT, elconf_scale)
 					+ SPACING + spin_button_width;
 				break;
+            case OPT_INT_S:
+            case OPT_FLOAT_S:
+                line_width = get_string_width_zoom(var->display.str, CONFIG_FONT, elconf_scale)
+                + SPACING + slider_width;
+                break;
 			case OPT_STRING:
 				// don't display the username, if it is changed after login, any name tagged files will be saved using the new name
 				if (strcmp(our_vars.var[i]->name, "username") == 0)
@@ -4081,6 +4197,8 @@ static void elconfig_populate_tabs(void)
 	int y_label, y_widget, dx, dy, iopt;
 	int spin_button_width = max2i(ELCONFIG_SCALED_VALUE(100),
 		4 * get_max_digit_width_zoom(CONFIG_FONT, elconf_scale) + 4 * (int)(0.5 + 5 * elconf_scale));
+    int slider_width = max2i(ELCONFIG_SCALED_VALUE(200),
+        4 * get_max_digit_width_zoom(CONFIG_FONT, elconf_scale) + 4 * (int)(0.5 + 5 * elconf_scale));
 #ifdef ANDROID
 	int right_margin = CHECKBOX_SIZE + TAB_MARGIN;
 #else
@@ -4161,6 +4279,35 @@ static void elconfig_populate_tabs(void)
 				widget_set_OnKey(window_id, widget_id, (int (*)())spinbutton_onkey_handler);
 				widget_set_OnClick(window_id, widget_id, spinbutton_onclick_handler);
 			break;
+            case OPT_INT_S:
+                label_id = label_add_extended(window_id, elconfig_free_widget_id++, NULL,
+                    current_x, current_y, 0, elconf_scale, (char*)var->display.str);
+                widget_width = slider_width;
+                widget_id = slider_add_extended(window_id, elconfig_free_widget_id++, NULL,
+#ifdef ANDROID
+                    window_width - right_margin - 2.0f * widget_width, current_y, 2.0f * widget_width, 2.0f * line_height,
+#else
+                    window_width - right_margin - widget_width, current_y, widget_width, line_height,
+#endif
+                    SLIDER_INT, var->var, var->args.imm.min,
+                    var->args.imm.max, elconf_scale);
+                widget_set_OnClick(window_id, widget_id, slider_onclick_handler);
+                widget_set_OnDrag(window_id, widget_id, slider_ondrag_handler);
+            break;
+            case OPT_FLOAT_S:
+                label_id = label_add_extended(window_id, elconfig_free_widget_id++, NULL,
+                    current_x, current_y, 0, elconf_scale, (char*)var->display.str);
+                widget_width = slider_width;
+                widget_id = slider_add_extended(window_id, elconfig_free_widget_id++, NULL,
+#ifdef ANDROID
+                    window_width - right_margin - 2.0f * widget_width, current_y, 2.0f * widget_width, 2.0f * line_height,
+#else
+                    window_width - right_margin - widget_width, current_y, widget_width, line_height,
+#endif
+                    SLIDER_FLOAT, var->var, var->args.fmm.min, var->args.fmm.max, elconf_scale);
+                widget_set_OnClick(window_id, widget_id, slider_onclick_handler);
+                widget_set_OnDrag(window_id, widget_id, slider_ondrag_handler);
+            break;
 			case OPT_STRING:
 				// don't display the username, if it is changed after login, any name tagged files will be saved using the new name
 				if (strcmp(var->name, "username") == 0)
@@ -4501,6 +4648,7 @@ void save_character_options(void)
 			{
 				case OPT_INT:
 				case OPT_INT_F:
+                case OPT_INT_S:
 				case OPT_MULTI:
 				case OPT_MULTI_H:
 				{
@@ -4521,6 +4669,7 @@ void save_character_options(void)
 					break;
 				}
 				case OPT_FLOAT:
+                case OPT_FLOAT_S:
 				{
 					if (json_character_options_exists(option->name))
 						if (*((float *)option->var) == json_character_options_get_float(option->name, *((float *)option->var)))
@@ -4581,6 +4730,7 @@ void load_character_options(void)
 			{
 				case OPT_INT:
 				case OPT_INT_F:
+                case OPT_INT_S:
 				{
 					int new_value = json_character_options_get_int(option->name, *((int *)option->var));
 					set_var_OPT_INT(option->name, new_value);
@@ -4607,6 +4757,7 @@ void load_character_options(void)
 					break;
 				}
 				case OPT_FLOAT:
+                case OPT_FLOAT_S:
 				{
 					float new_value = json_character_options_get_float(option->name, *((float *)option->var));
 					set_var_OPT_FLOAT(option->name, new_value);

--- a/elconfig.c
+++ b/elconfig.c
@@ -3048,7 +3048,7 @@ static void init_ELC_vars(void)
 	add_var(OPT_BOOL,"3d_map_markers","3dmarks",&marks_3d,change_var,1,"Enable 3D Map Markers","Shows user map markers in the game window",HUD);
 	add_var(OPT_BOOL,"filter_3d_map_markers","filter3dmarks",&filter_marks_3d,change_var,0,"Filter 3D Map Markers","Apply the current mark filter to 3d map marks.",HUD);
 	add_var(OPT_BOOL,"item_window_on_drop","itemdrop",&item_window_on_drop,change_var,1,"Item Window On Drop","Toggle whether the item window shows when you drop items",HUD);
-	add_var(OPT_FLOAT,"minimap_scale", "minimapscale", &local_minimap_size_coefficient, change_minimap_scale, 0.7, "Minimap Scale", "Adjust the overall size of the minimap", HUD, 0.5, 1.5, 0.1);
+	add_var(OPT_FLOAT_S,"minimap_scale", "minimapscale", &local_minimap_size_coefficient, change_minimap_scale, 0.7, "Minimap Scale", "Adjust the overall size of the minimap", HUD, 0.5, 1.5, 0.1);
 	add_var(OPT_BOOL,"rotate_minimap","rotateminimap",&rotate_minimap,change_var,1,"Rotate Minimap","Toggle whether the minimap should rotate.",HUD);
 	add_var(OPT_BOOL,"pin_minimap","pinminimap",&pin_minimap,change_var,0,"Pin Minimap","Toggle whether the minimap ignores close-all-windows.",HUD);
 	add_var(OPT_BOOL, "continent_map_boundaries", "cmb", &show_continent_map_boundaries, change_var, 1, "Map Boundaries On Continent Map", "Show map boundaries on the continent map", HUD);
@@ -3241,16 +3241,16 @@ static void init_ELC_vars(void)
 	add_var(OPT_STRING, "sound_device", "snddev", sound_device, change_string, sizeof(sound_device),
 		"Sound Device", "Device used for playing sounds & music", AUDIO);
 	add_var(OPT_BOOL,"enable_sound", "sound", &sound_on, toggle_sounds, 0, "Enable Sound Effects", "Turn sound effects on/off", AUDIO);
-	add_var(OPT_FLOAT,"sound_gain", "sgain", &sound_gain, change_sound_level, 1, "Overall Sound Effects Volume", "Adjust the overall sound effects volume", AUDIO, 0.0, 1.0, 0.1);
-	add_var(OPT_FLOAT,"crowd_gain", "crgain", &crowd_gain, change_sound_level, 1, "Crowd Sounds Volume", "Adjust the crowd sound effects volume", AUDIO, 0.0, 1.0, 0.1);
-	add_var(OPT_FLOAT,"enviro_gain", "envgain", &enviro_gain, change_sound_level, 1, "Environmental Sounds Volume", "Adjust the environmental sound effects volume", AUDIO, 0.0, 1.0, 0.1);
-	add_var(OPT_FLOAT,"actor_gain", "again", &actor_gain, change_sound_level, 1, "Character Sounds Volume", "Adjust the sound effects volume for fighting, magic and other character sounds", AUDIO, 0.0, 1.0, 0.1);
-	add_var(OPT_FLOAT,"walking_gain", "wgain", &walking_gain, change_sound_level, 1, "Walking Sounds Volume", "Adjust the walking sound effects volume", AUDIO, 0.0, 1.0, 0.1);
-	add_var(OPT_FLOAT,"gamewin_gain", "gwgain", &gamewin_gain, change_sound_level, 1, "Item and Inventory Sounds Volume", "Adjust the item and inventory sound effects volume", AUDIO, 0.0, 1.0, 0.1);
-	add_var(OPT_FLOAT,"client_gain", "clgain", &client_gain, change_sound_level, 1, "Misc Client Sounds Volume", "Adjust the client sound effects volume (warnings, hud/button clicks)", AUDIO, 0.0, 1.0, 0.1);
-	add_var(OPT_FLOAT,"warn_gain", "wrngain", &warnings_gain, change_sound_level, 1, "Text Warning Sounds Volume", "Adjust the user configured text warning sound effects volume", AUDIO, 0.0, 1.0, 0.1);
+	add_var(OPT_FLOAT_S,"sound_gain", "sgain", &sound_gain, change_sound_level, 1, "Overall Sound Effects Volume", "Adjust the overall sound effects volume", AUDIO, 0.0, 1.0, 0.1);
+	add_var(OPT_FLOAT_S,"crowd_gain", "crgain", &crowd_gain, change_sound_level, 1, "Crowd Sounds Volume", "Adjust the crowd sound effects volume", AUDIO, 0.0, 1.0, 0.1);
+	add_var(OPT_FLOAT_S,"enviro_gain", "envgain", &enviro_gain, change_sound_level, 1, "Environmental Sounds Volume", "Adjust the environmental sound effects volume", AUDIO, 0.0, 1.0, 0.1);
+	add_var(OPT_FLOAT_S,"actor_gain", "again", &actor_gain, change_sound_level, 1, "Character Sounds Volume", "Adjust the sound effects volume for fighting, magic and other character sounds", AUDIO, 0.0, 1.0, 0.1);
+	add_var(OPT_FLOAT_S,"walking_gain", "wgain", &walking_gain, change_sound_level, 1, "Walking Sounds Volume", "Adjust the walking sound effects volume", AUDIO, 0.0, 1.0, 0.1);
+	add_var(OPT_FLOAT_S,"gamewin_gain", "gwgain", &gamewin_gain, change_sound_level, 1, "Item and Inventory Sounds Volume", "Adjust the item and inventory sound effects volume", AUDIO, 0.0, 1.0, 0.1);
+	add_var(OPT_FLOAT_S,"client_gain", "clgain", &client_gain, change_sound_level, 1, "Misc Client Sounds Volume", "Adjust the client sound effects volume (warnings, hud/button clicks)", AUDIO, 0.0, 1.0, 0.1);
+	add_var(OPT_FLOAT_S,"warn_gain", "wrngain", &warnings_gain, change_sound_level, 1, "Text Warning Sounds Volume", "Adjust the user configured text warning sound effects volume", AUDIO, 0.0, 1.0, 0.1);
 	add_var(OPT_BOOL,"enable_music","music",&music_on,toggle_music,0,"Enable Music","Turn music on/off",AUDIO);
-	add_var(OPT_FLOAT,"music_gain","mgain",&music_gain,change_sound_level,1,"Music Volume","Adjust the music volume",AUDIO,0.0,1.0,0.1);
+	add_var(OPT_FLOAT_S,"music_gain","mgain",&music_gain,change_sound_level,1,"Music Volume","Adjust the music volume",AUDIO,0.0,1.0,0.1);
 #endif	//NEW_SOUND
 	// AUDIO TAB
 
@@ -3280,7 +3280,7 @@ static void init_ELC_vars(void)
 	add_var(OPT_INT,"video_height","height",&video_user_height,change_int, 480,"Userdefined height","Userdefined window height",VIDEO, 480,INT_MAX);
 	add_var(OPT_INT,"limit_fps","lfps",&limit_fps,change_fps,0,"Limit FPS","Limit the frame rate to reduce load on the system",VIDEO,0,INT_MAX);
 	add_var(OPT_BOOL,"enable_screensaver","esc",&enable_screensaver,change_screensaver,0,"Enable Desktop Screensaver","By default your desktop screen saver is disabled, this is normal behavour for games and media players. Set this option to enable the screensaver / monitor power managment.",VIDEO);
-	add_var(OPT_FLOAT,"gamma","g",&gamma_var,change_gamma,1,"Gamma","How bright your display should be.",VIDEO,0.10,3.00,0.05);
+	add_var(OPT_FLOAT_S,"gamma","g",&gamma_var,change_gamma,1,"Gamma","How bright your display should be.",VIDEO,0.10,3.00,0.05);
 	add_var(OPT_BOOL,"disable_gamma_adjust","dga",&disable_gamma_adjust,change_var,0,"Disable Gamma Adjustment","Stop the client from adjusting the display gamma.",VIDEO);
 #ifdef ANTI_ALIAS
 	add_var(OPT_BOOL,"anti_alias", "aa", &anti_alias, change_aa, 0, "Toggle Anti-Aliasing", "Anti-aliasing makes edges look smoother", VIDEO);
@@ -3347,10 +3347,10 @@ static void init_ELC_vars(void)
 
 
 	// CAMERA TAB
-	add_var(OPT_FLOAT,"far_plane", "far_plane", &far_plane, change_projection_float, 100.0, "Maximum Viewing Distance", "Adjusts how far you can see.", CAMERA, 40.0, 200.0, 1.0);
-	add_var(OPT_FLOAT,"far_reflection_plane", "far_reflection_plane", &far_reflection_plane, change_projection_float, 100.0, "Maximum Reflection Distance", "Adjusts how far the reflections are displayed.", CAMERA, 0.0, 200.0, 1.0);
-	add_var(OPT_FLOAT,"max_zoom_level","maxzoomlevel",&max_zoom_level,change_float,max_zoom_level,"Maximum Camera Zoom Out","Sets the maxiumum value that the camera can zoom out",CAMERA,4.0,8.0,0.5);
-	add_var(OPT_FLOAT,"perspective", "perspective", &perspective, change_projection_float, 0.15f, "Perspective", "The degree of perspective distortion. Change if your view looks odd.", CAMERA, 0.01, 0.80, 0.01);
+	add_var(OPT_FLOAT_S,"far_plane", "far_plane", &far_plane, change_projection_float, 100.0, "Maximum Viewing Distance", "Adjusts how far you can see.", CAMERA, 40.0, 200.0, 1.0);
+	add_var(OPT_FLOAT_S,"far_reflection_plane", "far_reflection_plane", &far_reflection_plane, change_projection_float, 100.0, "Maximum Reflection Distance", "Adjusts how far the reflections are displayed.", CAMERA, 0.0, 200.0, 1.0);
+	add_var(OPT_FLOAT_S,"max_zoom_level","maxzoomlevel",&max_zoom_level,change_float,max_zoom_level,"Maximum Camera Zoom Out","Sets the maxiumum value that the camera can zoom out",CAMERA,4.0,8.0,0.5);
+	add_var(OPT_FLOAT_S,"perspective", "perspective", &perspective, change_projection_float, 0.15f, "Perspective", "The degree of perspective distortion. Change if your view looks odd.", CAMERA, 0.01, 0.80, 0.01);
 	add_var(OPT_BOOL,"isometric" ,"isometric", &isometric, change_projection_bool, 1, "Use Isometric View", "Toggle the use of isometric (instead of perspective) view", CAMERA);
 	add_var(OPT_BOOL,"follow_cam","folcam", &fol_cam, toggle_follow_cam,0,"Follow Camera", "Causes the camera to stay fixed relative to YOU and not the world", CAMERA);
 	add_var(OPT_BOOL,"fol_cam_behind","fol_cam_behind", &fol_cam_behind, toggle_follow_cam_behind,0,"Keep the camera behind the char", "Causes the camera to stay behind you while walking (works only in follow camera mode)", CAMERA);

--- a/elconfig.c
+++ b/elconfig.c
@@ -1902,7 +1902,7 @@ int toggle_OPT_BOOL_by_name(const char *str)
 }
 
 #ifdef	ELC
-// find an OPT_INT ot OPT_INT_F widget and set its's value
+// Find an OPT_INT, OPT_INT_F, or OPT_INT_S widget and set its value
 int set_var_OPT_INT(const char *str, int new_value)
 {
     int var_index = find_var(str, INI_FILE_VAR);
@@ -1916,9 +1916,9 @@ int set_var_OPT_INT(const char *str, int new_value)
         our_vars.var[var_index]->func(our_vars.var[var_index]->var, new_value);
         our_vars.var[var_index]->saved = 0;
         
-        if(our_vars.var[var_index]->type == OPT_INT_S)
+        if(widget != NULL && widget->widget_info != NULL)
         {
-            if(widget != NULL && widget->widget_info != NULL)
+            if(our_vars.var[var_index]->type == OPT_INT_S)
             {
                 slider *s = widget->widget_info;
                 *(int *)s->data = new_value;
@@ -1928,10 +1928,7 @@ int set_var_OPT_INT(const char *str, int new_value)
                 s->pos = ((new_value - s->min) * 100) / (s->max - s->min);
                 return 1;
             }
-        }
-        else
-        {
-            if(widget != NULL && widget->widget_info != NULL)
+            else
             {
                 spinbutton *button = widget->widget_info;
                 *(int *)button->data = new_value;
@@ -1947,7 +1944,7 @@ int set_var_OPT_INT(const char *str, int new_value)
     return 0;
 }
 
-// find an OPT_FLOAT widget and set its's value
+// Find an OPT_FLOAT or OPT_FLOAT_S widget and set its value
 static int set_var_OPT_FLOAT(const char *str, float new_value)
 {
     int var_index = find_var(str, INI_FILE_VAR);
@@ -1961,9 +1958,9 @@ static int set_var_OPT_FLOAT(const char *str, float new_value)
         our_vars.var[var_index]->func(our_vars.var[var_index]->var, &new_value);
         our_vars.var[var_index]->saved = 0;
         
-        if(our_vars.var[var_index]->type == OPT_FLOAT_S)
+        if(widget != NULL && widget->widget_info != NULL)
         {
-            if(widget != NULL && widget->widget_info != NULL)
+            if(our_vars.var[var_index]->type == OPT_FLOAT_S)
             {
                 slider *s = widget->widget_info;
                 *(float *)s->data = new_value;
@@ -1973,10 +1970,7 @@ static int set_var_OPT_FLOAT(const char *str, float new_value)
                 s->pos = ((new_value - s->min) * 100) / (s->max - s->min);
                 return 1;
             }
-        }
-        else
-        {
-            if(widget != NULL && widget->widget_info != NULL)
+            else
             {
                 spinbutton *button = widget->widget_info;
                 *(float *)button->data = new_value;

--- a/elconfig.c
+++ b/elconfig.c
@@ -2227,7 +2227,14 @@ static void call_option_menu(var_struct *option)
 		if (get_use_json_user_files() && ready_for_user_files)
 		{
 			cm_add(cm_id, cm_options_per_character_str, NULL);
-			cm_bool_line(cm_id, 3, &option->character_override, NULL);
+            if(option->type == OPT_INT_S || option->type == OPT_FLOAT_S)
+            {
+                cm_bool_line(cm_id, 4, &option->character_override, NULL);
+            }
+            else
+            {
+                cm_bool_line(cm_id, 3, &option->character_override, NULL);
+            }
 		}
 #endif
 		cm_set_data(cm_id, (void *)option);

--- a/elconfig.h
+++ b/elconfig.h
@@ -90,6 +90,8 @@ typedef enum
 	OPT_FLOAT_F,       // Change float with functions that returns max and min values  func(float*,float*), max/min float func()
 	OPT_INT_F,         // Change int with functions that returns max and min values    func(int*,int), max/min int func()
 	// Values of _INI types are not displayed in the config window
+    OPT_FLOAT_S,       // Float with slider widget
+    OPT_INT_S,         // Int with slider widget
 	OPT_BOOL_INI,
 	OPT_STRING_INI,
 	OPT_INT_INI

--- a/translate.c
+++ b/translate.c
@@ -423,6 +423,7 @@ char
 	cm_encycl_base_str[150],
 	cm_options_default_str[50],
 	cm_options_initial_str[50],
+    cm_options_current_str[50],
 #ifdef JSON_FILES
 	cm_options_per_character_str[50],
 #endif
@@ -1833,6 +1834,7 @@ void init_help()
 	add_xml_identifier(misc, "cm_encycl_base", cm_encycl_base_str, "Encyclopedia Index\nSearch Encyclopedia Titles\nRepeat Last Search\nBookmark This Page\nUnbookmark This Page\nClear Bookmarks", sizeof(cm_encycl_base_str));
 	add_xml_identifier(misc, "cm_options_default", cm_options_default_str, "Set to default value", sizeof(cm_options_default_str));
 	add_xml_identifier(misc, "cm_options_initial", cm_options_initial_str, "Set to initial value", sizeof(cm_options_initial_str));
+    add_xml_identifier(misc, "cm_options_current", cm_options_current_str, "Current value", sizeof(cm_options_current_str));
 #ifdef JSON_FILES
 	add_xml_identifier(misc, "cm_options_per_character", cm_options_per_character_str, "Manage value just for this character", sizeof(cm_options_per_character_str));
 #endif

--- a/translate.h
+++ b/translate.h
@@ -572,6 +572,7 @@ extern char
 		cm_encycl_base_str[150],
 		cm_options_default_str[50],
 		cm_options_initial_str[50],
+    cm_options_current_str[50],
 #ifdef JSON_FILES
 		cm_options_per_character_str[50],
 #endif

--- a/widgets.c
+++ b/widgets.c
@@ -142,6 +142,9 @@ static int free_multiselect(widget_list *widget);
 static int spinbutton_draw(widget_list *widget);
 static int spinbutton_click(widget_list *widget, int mx, int my, Uint32 flags);
 static int spinbutton_keypress(widget_list *widget, int mx, int my, SDL_Keycode key_code, Uint32 key_unicode, Uint16 key_mod);
+static int slider_draw(widget_list *widget);
+static int slider_click(widget_list *widget, int mx, int my, Uint32 flags);
+static int slider_drag(widget_list *W, int x, int y, Uint32 flags, int dx, int dy);
 
 static const struct WIDGET_TYPE label_type = { NULL, label_draw, NULL, NULL, NULL, label_resize, NULL, free_widget_info, NULL, NULL, NULL, NULL };
 static const struct WIDGET_TYPE image_type = { NULL, image_draw, NULL, NULL, NULL, NULL, NULL, free_widget_info, NULL, NULL, NULL, NULL };
@@ -155,6 +158,7 @@ static const struct WIDGET_TYPE text_field_type = { NULL, text_field_draw, text_
 static const struct WIDGET_TYPE pword_field_type = { NULL, pword_field_draw, pword_field_click, pword_field_drag, pword_field_mouseover, NULL, (int (*)())pword_field_keypress, free_widget_info, NULL, NULL, pword_field_paste, NULL };
 static const struct WIDGET_TYPE multiselect_type = { NULL, multiselect_draw, multiselect_click, NULL, NULL, NULL, NULL, free_multiselect, NULL, NULL, NULL, multiselect_set_color };
 static const struct WIDGET_TYPE spinbutton_type = { NULL, spinbutton_draw, spinbutton_click, spinbutton_click, NULL, NULL, (int (*)())spinbutton_keypress, free_multiselect, NULL, NULL, NULL, NULL };
+static const struct WIDGET_TYPE slider_type = { NULL, slider_draw, slider_click, slider_drag, NULL, NULL, NULL, free_multiselect, NULL, NULL, NULL, NULL };
 
 // <--- Common widget functions ---
 widget_list * widget_find(int window_id, Uint32 widget_id)
@@ -4833,6 +4837,150 @@ int spinbutton_add_extended(int window_id, Uint32 wid, int (*OnInit)(), Uint16 x
 int spinbutton_add(int window_id, int (*OnInit)(), Uint16 x, Uint16 y, Uint16 lx, Uint16 ly, Uint8 data_type, void *data, float min, float max, float interval)
 {
 	return spinbutton_add_extended(window_id, widget_id++, OnInit, x, y, lx, ly, data_type, data, min, max, interval, 1);
+}
+
+// Slider
+static int slider_click(widget_list *widget, int mx, int my, Uint32 flags)
+{
+    if(widget != NULL && widget->widget_info != NULL) {
+        slider *s = widget->widget_info;
+        
+        // Do nothing if scrolling is involved, we don't want sliders jumping around
+        if(flags & (ELW_WHEEL_UP | ELW_WHEEL_DOWN))
+           return 0;
+        
+        // Calculate the current position of the slider as a percentage
+        int pos = ((mx) * 100) / (widget->len_x);
+        
+        // Check position is within bounds
+        if (pos < SLIDER_MIN)
+            s->pos = SLIDER_MIN;
+        else if (pos > SLIDER_MAX)
+            s->pos = SLIDER_MAX;
+        else
+            s->pos = pos;
+        
+        // Calculate the new value for this option based on the slider's position
+        switch (s->type) {
+            case SLIDER_INT:
+                *(int *)s->data = s->min + (s->pos * (s->max - s->min)) / 100;
+            break;
+            case SLIDER_FLOAT:
+                *(float *)s->data = s->min + (s->pos * (s->max - s->min)) / 100;
+            break;
+        }
+        
+        return 1;
+    }
+    return 0;
+}
+
+static int slider_drag(widget_list *W, int x, int y, Uint32 flags, int dx, int dy)
+{
+    if (!W)
+        return 0;
+
+    slider_click(W, x, y, flags);
+
+    return 1;
+}
+
+static int slider_draw(widget_list *widget)
+{
+    slider *slider;
+    int arrow_size, handle_width, handle_position;
+
+    if(widget == NULL || (slider = widget->widget_info) == NULL) {
+        return 0;
+    }
+
+    arrow_size = (int)(0.5 + (float)(widget->len_y) / 4.0f);
+
+    glDisable(GL_TEXTURE_2D);
+    glColor3f(widget->r, widget->g, widget->b);
+
+    /* Slider Spine */
+    glBegin(GL_LINES);
+        glVertex3i (widget->pos_x, widget->pos_y + widget->len_y/2, 0);
+        glVertex3i (widget->pos_x + widget->len_x, widget->pos_y + widget->len_y/2, 0);
+    glEnd();
+    
+    /* Slider Left Cap */
+    glBegin(GL_LINES);
+        glVertex3i (widget->pos_x+1, widget->pos_y+2, 0);
+        glVertex3i (widget->pos_x+1, widget->pos_y+widget->len_y-2, 0);
+    glEnd();
+    
+    /* Slider Right Cap */
+    glBegin(GL_LINES);
+    glVertex3i (widget->pos_x+widget->len_x-1, widget->pos_y+2, 0);
+    glVertex3i (widget->pos_x+widget->len_x-1, widget->pos_y+widget->len_y-2, 0);
+    glEnd();
+    
+    /* Slider Handle */
+    handle_width = 2 * arrow_size - (int)(0.5 + (float)arrow_size / 1.5f);
+    
+    // Calculate the x position of the slider handle based on percentages
+    handle_position = (widget->len_x/100) * slider->pos;
+    
+    // Make sure we don't go beyond the end of the slider
+    if (handle_position > (widget->len_x - handle_width))
+    {
+        handle_position = widget->len_x - handle_width;
+    }
+    
+    glBegin(GL_QUADS);
+    // TOP LEFT
+    glVertex3i(widget->pos_x + handle_position,
+               widget->pos_y + 0, 0);
+    
+    // TOP RIGHT
+    glVertex3i(widget->pos_x + handle_position + handle_width,
+               widget->pos_y + 0, 0);
+    
+    // BOTTOM RIGHT
+    glVertex3i(widget->pos_x + handle_position + handle_width,
+               widget->pos_y + widget->len_y, 0);
+    
+    // BOTTOM LEFT
+    glVertex3i(widget->pos_x + handle_position,
+               widget->pos_y + widget->len_y, 0);
+    glEnd();
+
+    glEnable(GL_TEXTURE_2D);
+#ifdef OPENGL_TRACE
+CHECK_GL_ERRORS();
+#endif //OPENGL_TRACE
+    return 1;
+}
+
+int slider_add_extended(int window_id, Uint32 wid, int (*OnInit)(), Uint16 x, Uint16 y, Uint16 lx, Uint16 ly, Uint8 data_type, void *data, float min, float max, float size)
+{
+    slider *T = calloc (1, sizeof (slider));
+    // Filling the widget info
+    T->data = data;
+    T->max = max;
+    T->min = min;
+    T->type = data_type;
+    
+    switch(data_type)
+    {
+        case SLIDER_FLOAT:
+            safe_snprintf(T->input_buffer, sizeof(T->input_buffer), "%.2f", *(float *)T->data);
+            T->pos = ((*(float *)data - T->min) * 100) / (T->max - T->min);
+        break;
+        case SLIDER_INT:
+            safe_snprintf(T->input_buffer, sizeof(T->input_buffer), "%i", *(int *)T->data);
+            T->pos = ((*(int *)data - T->min) * 100) / (T->max - T->min);
+        break;
+    }
+
+    return widget_add(window_id, wid, OnInit, x, y, lx, ly, 0, size, &slider_type, T, NULL);
+}
+
+int slider_add(int window_id, int (*OnInit)(), Uint16 x, Uint16 y, Uint16 lx, Uint16 ly, Uint8 data_type, void *data, float min, float max)
+{
+    return slider_add_extended(window_id, widget_id++, OnInit, x, y, lx, ly, data_type, data, min, max, 1);
 }
 
 // Helper functions for widgets

--- a/widgets.h
+++ b/widgets.h
@@ -194,6 +194,15 @@ typedef struct {
 	float interval;
 }spinbutton;
 
+typedef struct {
+    void *data;
+    char input_buffer[255];
+    float max;
+    float min;
+    Uint8 type;
+    int pos;
+}slider;
+
 /* SPLIT INTO ELWIDGETS.C and ELWIDGETS.H */
 
 // Common widget functions
@@ -1384,6 +1393,14 @@ int multiselect_set_scrollbar_inc(int window_id, Uint32 multiselect_id, int inc)
 
 int spinbutton_add(int window_id, int (*OnInit)(), Uint16 x, Uint16 y, Uint16 lx, Uint16 ly, Uint8 data_type, void *data, float min, float max, float interval);
 int spinbutton_add_extended(int window_id, Uint32 widget_id, int (*OnInit)(), Uint16 x, Uint16 y, Uint16 lx, Uint16 ly, Uint8 data_type, void *data, float min, float max, float interval, float size);
+
+#define SLIDER_FLOAT 0
+#define SLIDER_INT 1
+#define SLIDER_MIN 0
+#define SLIDER_MAX 100
+
+int slider_add(int window_id, int (*OnInit)(), Uint16 x, Uint16 y, Uint16 lx, Uint16 ly, Uint8 data_type, void *data, float min, float max);
+int slider_add_extended(int window_id, Uint32 widget_id, int (*OnInit)(), Uint16 x, Uint16 y, Uint16 lx, Uint16 ly, Uint8 data_type, void *data, float min, float max, float size);
 
 /*!
  * \ingroup	widgets


### PR DESCRIPTION
Here’s a PR for a new “slider” widget type I have been working on. It is intended for use in the options window as the first part of an effort to make that area of the interface less cluttered and more intuitive for the user.

As is typically the case with UI sliders, the absolute value of the option is now no longer directly shown to the user within the interface. To make this a little more palatable to those who may miss it, I have added an extra line to the right-click context menu which displays the current value of the option. This change applies to slider options only.

I have updated some candidate options to use the new option type, these are very conservative changes based on Human Interface Guidelines from Gnome and Apple (thanks for the guidance, @pjbroad!). If the new widget type is approved I am happy to make adjustments to these selections as discussion progresses 😊

It would be useful if android folks could have a play around with the new widget, as I unfortunately do not possess a device capable of running the android client.

<img width="576" alt="Screenshot 2025-02-26 at 08 19 07" src="https://github.com/user-attachments/assets/98f105e4-4801-443b-a6ea-6f12a4c90980" />

https://github.com/user-attachments/assets/2cb3f1f1-c227-4b63-aca9-9ec29bdd0e4e