### PR TITLE
Rename scale to anim_scale

### DIFF
--- a/actor_scripts.c
+++ b/actor_scripts.c
@@ -1841,7 +1841,7 @@ static void next_actor_command(actor* act, actor *attached, void* UNUSED(data),
 					if (actors_defs[actor_type].actor_scale != 1.0)
 						act->cur_anim.duration_scale /= actors_defs[actor_type].actor_scale;
 					else
-						act->cur_anim.duration_scale /= actors_defs[actor_type].scale;
+						act->cur_anim.duration_scale /= actors_defs[actor_type].anim_scale;
 					if (dx != 0 && dy != 0)
 						act->cur_anim.duration_scale *= 1.4142315;
 				}
@@ -3905,7 +3905,7 @@ struct cal_anim cal_load_idle(actor_types *act, char *str)
 	};
 	struct CalCoreAnimation *coreanim;
 
-	res.anim_index=CalCoreModel_ELLoadCoreAnimation(act->coremodel,str,act->scale);
+	res.anim_index=CalCoreModel_ELLoadCoreAnimation(act->coremodel,str,act->anim_scale);
 	if(res.anim_index == -1) {
 		LOG_ERROR("Cal3d error: %s: %s\n", str, CalError_GetLastErrorDescription());
 		return res;
@@ -4494,8 +4494,8 @@ int parse_actor_nodes(actor_types *act, const xmlNode *cfg, const xmlNode *defau
 				get_string_value(act->file_name, sizeof (act->file_name), item);
 			} else if (!strcmp(name, "actor_scale")) {
 				act->actor_scale= get_float_value(item);
-			} else if (!strcmp(name, "scale")) {
-				act->scale= get_float_value(item);
+			} else if (!strcmp(name, "scale")) { // TODO: Rename to anim_scale once xml is updated.
+				act->anim_scale= get_float_value(item);
 			} else if (!strcmp(name, "mesh_scale")) {
 				act->mesh_scale= get_float_value(item);
 			} else if (!strcmp(name, "bone_scale")) {
@@ -4601,9 +4601,9 @@ int parse_actor_script(const xmlNode *cfg)
 	//Initialize Cal3D settings
 	act->coremodel= NULL;
 	act->actor_scale= 1.0;
-	act->scale= 1.0;
 	act->mesh_scale= 1.0;
 	act->skel_scale= 1.0;
+	act->anim_scale= 1.0;
 	act->group_count= 0;
 	for (i=0; i<16; ++i) {
 		safe_strncpy(act->idle_group[i].name, "", sizeof(act->idle_group[i].name));

--- a/actors.c
+++ b/actors.c
@@ -489,7 +489,7 @@ static void draw_actor_banner(actor *actor_id, const actor *me, float offset_z)
 	glGetDoublev(GL_PROJECTION_MATRIX, proj);
 	glGetIntegerv(GL_VIEWPORT, view);
 	// Input adjusted healthbar_y value to scale hy according to actor scale
-	gluProject(healthbar_x, healthbar_y, healthbar_z * actor_id->scale * actors_defs[actor_id->actor_type].actor_scale + 0.02, model, proj, view, &hx, &hy, &hz);
+	gluProject(healthbar_x, healthbar_y, healthbar_z * get_actor_scale(actor_id) + 0.02, model, proj, view, &hx, &hy, &hz);
 
 	//Save World-view and Projection matrices to allow precise raster placement of quads
 	glPushMatrix();

--- a/actors.h
+++ b/actors.h
@@ -308,10 +308,15 @@ typedef struct
 	char file_name[256];
 	/*! \} */
 
+	// Actor model scale (outside Cal3D).
 	float actor_scale;
-	float scale;
+	// Cal3D mesh geometry scale.
 	float mesh_scale;
+	// Cal3D skeleton scale.
 	float skel_scale;
+	// Cal3D animation scale. Generally this should be the same as the skeleton
+	// scale unless you want to intentionally deform the mesh during animations.
+	float anim_scale;
 
 	struct CalCoreModel *coremodel;
 	struct CalHardwareModel* hardware_model;
@@ -733,11 +738,10 @@ static __inline__ float get_actor_z(const actor *a)
  * \param a the actor
  * \return the scale factor of the actor
  */
-static __inline__ float get_actor_scale(const actor *a)
+static __inline__ float get_actor_scale(const actor *act)
 {
-	float scale = a->scale;
-	scale *= actors_defs[a->actor_type].actor_scale;
-	return scale;
+	// Actor's dynamic scale received from server * static scale read from actor def xml.
+	return act->scale * actors_defs[act->actor_type].actor_scale;
 }
 
 /*!

--- a/cal.c
+++ b/cal.c
@@ -394,7 +394,7 @@ struct cal_anim cal_load_anim(actor_types *act, const char *str, int duration)
 		res.sound_scale = 1.0f;
 #endif	//NEW_SOUND
 
-	res.anim_index=CalCoreModel_ELLoadCoreAnimation(act->coremodel,fname,act->scale);
+	res.anim_index=CalCoreModel_ELLoadCoreAnimation(act->coremodel,fname,act->anim_scale);
 	if(res.anim_index == -1) {
 		LOG_ERROR("Cal3d error: %s: %s\n", fname, CalError_GetLastErrorDescription());
 		return res;
@@ -619,13 +619,10 @@ void cal_render_actor(actor *act, Uint32 use_lightning, Uint32 use_textures, Uin
 	skel=CalModel_GetSkeleton(act->calmodel);
 
 	glPushMatrix();
-	// actor model rescaling
-	if(actors_defs[act->actor_type].actor_scale != 1.0){
-		glScalef(actors_defs[act->actor_type].actor_scale, actors_defs[act->actor_type].actor_scale, actors_defs[act->actor_type].actor_scale);
-	}
-	// the dynamic scaling
-	if(act->scale != 1.0f){
-		glScalef(act->scale,act->scale,act->scale);
+
+	float scale = get_actor_scale(act);
+	if (scale != 1.0){
+		glScalef(scale, scale, scale);
 	}
 
 #ifdef	DYNAMIC_ANIMATIONS


### PR DESCRIPTION
Another small rename I hope you'll consider.

From what I can ascertain, actors may have several different scales in their def files: `actor_scale`, `mesh_scale`, `bone_scale`, and `scale`.  My PR concerns this last one, `scale`. The current naming is a bit ambiguous and the purpose of it is not clear. At first I thought it might be associated with `actor->scale`, but no, that's dynamic scaling that is applied via `ADD_NEW_ENHANCED_ACTOR`.

After digging through the code a bit I can see this `scale` is only used in 3 places: for scaling the Cal3D animation keyframe translations. So it's an _animation_ scale. For this reason, I'd like to suggest renaming it to `anim_scale`. It'd be nice to rename the `scale` elements in the xml files too.

**Fun fact:**
For animations it's typically best to use the skeleton scale (`bone_scale`) or you risk the mesh becoming deformed when animating, so I questioned why EL has this separate animation scale in the first place. Looking at the actor def files, I found that big spiders are the _only_ actors with an animation scale that is different from the skeleton scale. Their skeleton is much smaller than the mesh, which results in the mesh becoming a bit deformed when animating. Here's their walking animation slowed down:

https://github.com/user-attachments/assets/baccfc4b-7b7a-46ae-bc73-adc3f51b4a82

Increasing the skeleton size to match the mesh results in a much nicer animation and mesh: 

https://github.com/user-attachments/assets/b00abce8-5a2c-4432-8405-956a7ecfb976

I was going to make a PR removing the redundant animation scale entirely in favor of skeleton scale, but then when I set the animation speed back to normal I saw why the deviation was needed for big spiders – the walking animation simply doesn't look good when the skeleton is properly sized:

https://github.com/user-attachments/assets/9357a627-9efe-4133-a88f-acbaef2c5336

So unfortunately because of spiders the separate animation scale is still needed.