### PR TITLE
Player Banner Always on Top

### DIFF
--- a/actors.c
+++ b/actors.c
@@ -67,6 +67,7 @@ static size_t no_near_actors = 0;
 static near_actor *near_actors = NULL;
 
 int cm_mouse_over_banner = 0;		/* use to trigger banner context menu */
+int player_banner_on_top = 1; /* Player banner gets unobstructed */
 
 //return the newly allocated actor
 static actor* create_actor (int actor_type, char * skin_name, float x_pos, float y_pos, float z_pos, float z_rot, float scale, char remappable, short skin_color, short hair_color, short eyes_color, short shirt_color, short pants_color, short boots_color, int actor_id)
@@ -490,7 +491,9 @@ static void draw_actor_banner(actor *actor_id, const actor *me, float offset_z)
 	glGetIntegerv(GL_VIEWPORT, view);
 	// Input adjusted healthbar_y value to scale hy according to actor scale
 	gluProject(healthbar_x, healthbar_y, healthbar_z * actor_id->scale * actors_defs[actor_id->actor_type].actor_scale + 0.02, model, proj, view, &hx, &hy, &hz);
-
+	if (displaying_me && player_banner_on_top) {
+		hz = hz - 0.9; // force banner to be on top of everything
+	}
 	//Save World-view and Projection matrices to allow precise raster placement of quads
 	glPushMatrix();
 	glLoadIdentity();

--- a/actors.h
+++ b/actors.h
@@ -30,6 +30,7 @@ extern int yourself; 	/*!< This variable holds the actor_id (as the server sees 
 extern int you_sit; 	/*!< Specifies if you are currently sitting down.*/
 extern int sit_lock; 	/*!< The sit_lock variable holds you in a sitting position.*/
 extern int use_alpha_banner;	/*!< Use_alpha_banner defines if an alpha background is drawn behind the name/health banner.*/
+extern int player_banner_on_top; /*!< The player's overhead banner will be on top of all other banners and objects, so it will never be obstructed */
 
 /*!
  * \name	Actor types

--- a/elconfig.c
+++ b/elconfig.c
@@ -3108,6 +3108,7 @@ static void init_ELC_vars(void)
 	add_var(OPT_BOOL,"player_dynamic_banner_colour", "pdbc", &dynamic_banner_colour.other_players, change_var, 1, "Dynamic Other Players Health Banner Colour", "Dynamically change the colour of the health banner for other players. It changes from green to red as they loose health.",HUD);
 	add_var(OPT_BOOL,"creature_dynamic_banner_colour", "cdbc", &dynamic_banner_colour.creatures, change_var, 1, "Dynamic Creatures Health Banner Colour", "Dynamically change the colour of the health banner for creatures. It changes from green to red as they loose health.",HUD);
 
+	add_var(OPT_BOOL,"player_banner_on_top", "pbot", &player_banner_on_top, change_var, 1, "Player Banner Always On Top", "Your banner will appear over all other banners and objects, so it's never obstructed.",HUD);
 	// instance mode options
 	add_var(OPT_BOOL,"use_view_mode_instance","instance_mode",&view_mode_instance, change_var, 0, "Use instance mode banners", "Shows only your and mobs banners, adds mana bar to your banner.",HUD);
 	add_var(OPT_FLOAT,"instance_mode_banner_height","instance_mode_bheight",&view_mode_instance_banner_height,change_float,5.0f,"Your instance banner height","Sets how high the banner is located above your character",HUD,1.0,12.0,0.2);


### PR DESCRIPTION
This will set the player's banner to always be on top of any other banners or 3d objects, ensuring its view is never obstructed.

Closes #222